### PR TITLE
build: use gen2 macOS executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
   test-mac:
     macos:
       xcode: "13.0.0"
+    resource_class: macos.x86.medium.gen2
     parameters:
       node-version:
         description: Node.js version to install


### PR DESCRIPTION
Currently macOS jobs aren't being executed, might be due to this, so switching it over.