### PR TITLE
fix: use URI.fsPath to get valid Windows paths

### DIFF
--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -119,36 +119,36 @@ export class DocsWorkspace implements IWorkspace {
   }
 
   hasMarkdownDocument(resource: URI) {
-    const relativePath = path.relative(URI.file(this.root).path, resource.path);
+    const relativePath = path.relative(path.resolve(this.root), resource.fsPath);
     return (
       !relativePath.startsWith('..') &&
       !path.isAbsolute(relativePath) &&
-      fs.existsSync(resource.path)
+      fs.existsSync(resource.fsPath)
     );
   }
 
   async openMarkdownDocument(resource: URI) {
-    if (!this.documentCache.has(resource.path)) {
+    if (!this.documentCache.has(resource.fsPath)) {
       try {
         const document = TextDocument.create(
           resource.toString(),
           'markdown',
           1,
-          fs.readFileSync(resource.path, 'utf8'),
+          fs.readFileSync(resource.fsPath, 'utf8'),
         );
 
-        this.documentCache.set(resource.path, document);
+        this.documentCache.set(resource.fsPath, document);
       } catch {
         return undefined;
       }
     }
 
-    return this.documentCache.get(resource.path);
+    return this.documentCache.get(resource.fsPath);
   }
 
   async stat(resource: URI): Promise<FileStat | undefined> {
     if (this.hasMarkdownDocument(resource)) {
-      const stats = fs.statSync(resource.path);
+      const stats = fs.statSync(resource.fsPath);
       return { isDirectory: stats.isDirectory() };
     }
 

--- a/tests/electron-lint-markdown-links.spec.ts
+++ b/tests/electron-lint-markdown-links.spec.ts
@@ -37,7 +37,7 @@ describe('electron-lint-markdown-links', () => {
       '--root',
       FIXTURES_DIR,
       '--ignore',
-      '**/broken-*-link.md',
+      '**/{broken,valid}-*-link.md',
       '*.md',
     );
 
@@ -51,7 +51,7 @@ describe('electron-lint-markdown-links', () => {
       '--ignore',
       '**/broken-{external,internal}-link.md',
       '--ignore',
-      '**/broken-cross-file-link.md',
+      '**/{broken,valid}-cross-file-link.md',
       '*.md',
     );
 
@@ -79,6 +79,17 @@ describe('electron-lint-markdown-links', () => {
 
     expect(stdout.toString('utf-8')).toContain('Broken link');
     expect(status).toEqual(1);
+  });
+
+  it('should allow valid cross-file links', () => {
+    const { status, stdout } = runLintMarkdownLinks(
+      '--root',
+      FIXTURES_DIR,
+      'valid-cross-file-link.md'
+    );
+
+    expect(stdout.toString('utf-8')).toEqual(expect.not.stringContaining('Broken link'));
+    expect(status).toEqual(0);
   });
 
   it('should by default ignore broken external links', () => {

--- a/tests/fixtures/ignorepaths
+++ b/tests/fixtures/ignorepaths
@@ -1,2 +1,3 @@
 **/broken-{external,internal}-link.md
 **/broken-cross-file-link.md
+**/valid-cross-file-link.md

--- a/tests/fixtures/valid-cross-file-link.md
+++ b/tests/fixtures/valid-cross-file-link.md
@@ -1,0 +1,1 @@
+Link to [target section](./broken-internal-link.md)


### PR DESCRIPTION
After some debugging, I've figured out the Windows issue I've been encountering.

Calling `URI.path` for a `file://` URI returns a string that starts with a leading slash, so for example:

```
"file:///c%3A/Users/test/some-file.md"
```

Would become:

```
"/C:/Users/test/some-file.md"
```

That path is *not* a valid Windows path, so calls to `fs.existsSync` etc. will fail even though that target Markdown file exists on disk.

After digging around a little in `vscode-uri`, I found that they have a separate [fsPath](https://github.com/microsoft/vscode-uri/blob/1af8b2576342c7e6deff4d4a2c2e6cdfda170ff2/src/uri.ts#L204) property which seems to behave how we actually want it to behave, returning a string like:

```
"C:\\Users\\test\\some-file.md"
```

While debugging this, I also found that there aren't actually any test fixtures for *valid* markdown doc links (which explains why the tests were green on Windows). I added one test fixture for a valid cross-doc link to help verify that this actually fixes something.