### PR TITLE
feat: lint JS in Markdown files with standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ across repos. To use the base config, extend it in `.markdownlint.json`:
 `electron-markdownlint` is provided as a wrapper command which adds extra
 rules found in this package automatically.
 
-`electron-lint-markdown-links` is a command to further link links to find
+`electron-lint-markdown-links` is a command to further lint links to find
 broken relative links, including URL fragments, and can also be used to
 check external links with the `--fetch-external-links` option.
+
+`electron-lint-markdown-standard` is a command to lint JS code blocks in
+Markdown with `standard`, like `standard-markdown` does, but with better
+detection of code blocks.
 
 ## License
 

--- a/bin/lint-markdown-standard.ts
+++ b/bin/lint-markdown-standard.ts
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import * as minimist from 'minimist';
+
+import { TextDocument, TextEdit, Range } from 'vscode-languageserver-textdocument';
+import { URI } from 'vscode-uri';
+
+import { getCodeBlocks, DocsWorkspace } from '../lib/markdown';
+
+interface Options {
+  fix?: boolean;
+  ignoreGlobs?: string[];
+}
+
+interface LintMessage {
+  ruleId: string;
+  message: string;
+  line: number;
+  column: number;
+}
+
+interface LintResult {
+  filePath: string;
+  messages: LintMessage[];
+  errorCount: number;
+  warningCount: number;
+  output?: string;
+}
+
+const DISABLED_RULES = [
+  'no-labels',
+  'no-lone-blocks',
+  'no-undef',
+  'no-unused-expressions',
+  'no-unused-vars',
+  'n/no-callback-literal',
+];
+
+// Helper function to work around import issues with ESM module
+// eslint-disable-next-line no-new-func
+const dynamicImport = new Function('specifier', 'return import(specifier)');
+
+// From zeke/standard-markdown
+function removeParensWrappingOrphanedObject(block: string) {
+  return block.replace(/^\(([{|[][\s\S]+[}|\]])\)$/gm, '$1');
+}
+
+// From zeke/standard-markdown
+function wrapOrphanObjectInParens(block: string) {
+  return block.replace(/^([{|[][\s\S]+[}|\]])$/gm, '($1)');
+}
+
+async function main(
+  workspaceRoot: string,
+  globs: string[],
+  { fix = false, ignoreGlobs = [] }: Options,
+) {
+  const { default: standard } = await dynamicImport('standard');
+
+  const workspace = new DocsWorkspace(workspaceRoot, globs, ignoreGlobs);
+
+  let lastFilePath: string | undefined;
+  let totalErrors = 0;
+
+  for (const document of await workspace.getAllMarkdownDocuments()) {
+    const uri = URI.parse(document.uri);
+    const filepath = workspace.getWorkspaceRelativePath(uri);
+    const changes: TextEdit[] = [];
+
+    const jsCodeBlocks = (await getCodeBlocks(document)).filter(
+      (code) => code.lang && ['javascript', 'js'].includes(code.lang.toLowerCase()),
+    );
+
+    for (const codeBlock of jsCodeBlocks) {
+      if (codeBlock.lang && codeBlock.lang.toLowerCase() !== codeBlock.lang) {
+        totalErrors += 1;
+
+        if (filepath !== lastFilePath) {
+          console.log(`\n   ${filepath}`);
+          lastFilePath = filepath;
+        }
+
+        const line = codeBlock.position!.start.line;
+        const column = codeBlock.position!.start.column;
+        const lineInfo = `${line}:${column}: `.padEnd(10);
+        console.log(`         ${lineInfo}Code block language identifier should be all lowercase`);
+      }
+
+      // Skip empty code blocks
+      if (!codeBlock.value.trim()) {
+        continue;
+      }
+
+      const eslintDisable = `/* eslint-disable ${DISABLED_RULES.join(', ')} */`;
+
+      const results: LintResult[] = await standard.lintText(
+        `${eslintDisable}\n${wrapOrphanObjectInParens(codeBlock.value)}\n`,
+        fix ? { fix: true } : undefined,
+      );
+
+      for (const result of results) {
+        totalErrors += result.errorCount + result.warningCount;
+
+        for (const message of result.messages) {
+          if (filepath !== lastFilePath) {
+            console.log(`\n   ${filepath}`);
+            lastFilePath = filepath;
+          }
+
+          const line = codeBlock.position!.start.line - 1;
+          const lineInfo = `${line + message.line}:${message.column}: `.padEnd(10);
+          console.log(`         ${lineInfo}${message.message}`);
+        }
+
+        if (fix && result.output) {
+          const newText = removeParensWrappingOrphanedObject(
+            result.output.slice(`${eslintDisable}\n`.length),
+          );
+
+          // The code block position includes the surrounding code fence,
+          // so use the line numbers inside of the code fence. Note that
+          // the code block positions are 1-based, but Range uses 0-based
+          const range: Range = {
+            start: {
+              line: codeBlock.position!.start.line,
+              character: 0,
+            },
+            end: {
+              line: codeBlock.position!.end.line - 2,
+              character: Number.POSITIVE_INFINITY,
+            },
+          };
+          changes.push({ range, newText });
+        }
+      }
+    }
+
+    if (fix && changes.length) {
+      console.log(`File has changed: ${workspace.getWorkspaceRelativePath(uri)}`);
+      fs.writeFileSync(uri.fsPath, TextDocument.applyEdits(document, changes));
+    }
+  }
+
+  console.log(`\nThere are ${totalErrors} errors in '${workspaceRoot}'`);
+
+  return totalErrors > 0;
+}
+
+function parseCommandLine() {
+  const showUsage = (arg?: string): boolean => {
+    if (!arg || arg.startsWith('-')) {
+      console.log(
+        'Usage: electron-lint-markdown-standard --root <dir> <globs> [-h|--help] [--fix]' +
+          '[--ignore <globs>] [--ignore-path <path>]',
+      );
+      process.exit(1);
+    }
+
+    return true;
+  };
+
+  const opts = minimist(process.argv.slice(2), {
+    boolean: ['help', 'fix'],
+    string: ['root', 'ignore', 'ignore-path'],
+    unknown: showUsage,
+  });
+
+  if (opts.help || !opts.root || !opts._.length) showUsage();
+
+  return opts;
+}
+
+if (require.main === module) {
+  const opts = parseCommandLine();
+
+  if (opts.ignore) {
+    opts.ignore = Array.isArray(opts.ignore) ? opts.ignore : [opts.ignore];
+  } else {
+    opts.ignore = [];
+  }
+
+  if (opts['ignore-path']) {
+    const ignores = fs.readFileSync(path.resolve(opts['ignore-path']), { encoding: 'utf-8' });
+
+    for (const ignore of ignores.split('\n')) {
+      opts.ignore.push(ignore.trimEnd());
+    }
+  }
+
+  main(path.resolve(process.cwd(), opts.root), opts._, {
+    fix: opts.fix,
+    ignoreGlobs: opts.ignore,
+  })
+    .then((errors) => {
+      if (errors) process.exit(1);
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "bin": {
     "electron-markdownlint": "./dist/bin/markdownlint-cli-wrapper.js",
-    "electron-lint-markdown-links": "./dist/bin/lint-markdown-links.js"
+    "electron-lint-markdown-links": "./dist/bin/lint-markdown-links.js",
+    "electron-lint-markdown-standard": "./dist/bin/lint-markdown-standard.js"
   },
   "directories": {
     "lib": "lib"
@@ -59,6 +60,7 @@
     "mdast-util-from-markdown": "^1.3.0",
     "minimist": "^1.2.8",
     "node-fetch": "^2.6.9",
+    "standard": "^17.0.0",
     "unist-util-visit": "^4.1.2",
     "vscode-languageserver": "^8.1.0",
     "vscode-languageserver-textdocument": "^1.0.8",

--- a/tests/__snapshots__/electron-lint-markdown-standard.spec.ts.snap
+++ b/tests/__snapshots__/electron-lint-markdown-standard.spec.ts.snap
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`electron-lint-markdown-standard can detect errors in code blocks 1`] = `
+"
+   dirty.md
+         6:1:      Unexpected var, use let or const instead.
+         6:12:     Extra semicolon.
+         20:1:     Unexpected var, use let or const instead.
+         20:12:    Extra semicolon.
+         21:9:     Expected '===' and instead saw '=='.
+         21:27:    Strings must use singlequote.
+         21:40:    Extra semicolon.
+         27:1:     Unexpected var, use let or const instead.
+         27:12:    Extra semicolon.
+         28:9:     Expected '===' and instead saw '=='.
+         28:27:    Strings must use singlequote.
+         28:40:    Extra semicolon.
+         33:1:     Code block language identifier should be all lowercase
+         34:1:     Unexpected var, use let or const instead.
+         34:12:    Extra semicolon.
+
+There are 15 errors in '<root>'
+"
+`;
+
+exports[`electron-lint-markdown-standard can fix cleanable errors with --fix option 1`] = `
+"# The Cleanable Readme
+
+This is a markdown file with some javascript code blocks in it.
+
+\`\`\`js
+const foo = 1
+\`\`\`
+
+Each block is parsed separately, to avoid linting errors about variable
+assignment. Notice that \`var foo\` occurs twice in this markdown file,
+but only once in each individual snippet.
+
+The following code block has a few issues:
+
+- semicolons
+- type-insensitive equality comparison
+- double-quoted string
+
+\`\`\`javascript
+const foo = 2
+console.log('foo is two')
+\`\`\`
+
+Same as before, but with metadata:
+
+\`\`\`javascript title='main.js'
+const foo = 2
+console.log('foo is two')
+\`\`\`
+
+This non-js code block should be ignored by the cleaner and the linter:
+
+\`\`\`sh
+echo i am a shell command
+\`\`\`
+
+It should allow orphan objects:
+
+\`\`\`js
+{ some: 'object' }
+\`\`\`
+
+and this wrapping kind too:
+
+\`\`\`js
+{
+  some: 'object',
+  with: 'different whitespace and tabbing'
+}
+\`\`\`
+
+and arrays:
+
+\`\`\`js
+[1, 2, 3]
+\`\`\`
+
+and wrapped arrays:
+
+\`\`\`js
+[
+  4,
+  5,
+  6
+]
+\`\`\`
+"
+`;
+
+exports[`electron-lint-markdown-standard outputs uncleanable errors with --fix option 1`] = `
+"# The Dirty Readme
+
+This is a markdown file with some javascript code blocks in it.
+
+\`\`\`js
+const foo = 1
+\`\`\`
+
+Each block is parsed separately, to avoid linting errors about variable
+assignment. Notice that \`var foo\` occurs twice in this markdown file,
+but only once in each individual snippet.
+
+The following code block has a few issues:
+
+- semicolons
+- type-insensitive equality comparison
+- double-quoted string
+
+\`\`\`javascript
+const foo = 2
+if (foo == 1) console.log('foo is one')
+\`\`\`
+
+Same as before, but with metadata:
+
+\`\`\`javascript title='main.js'
+const foo = 2
+if (foo == 1) console.log('foo is one')
+\`\`\`
+
+Blocks should have lowercase language identifiers:
+
+\`\`\`JavaScript
+const foo = 3
+\`\`\`
+
+This non-js code block should be ignored by the linter:
+
+\`\`\`sh
+echo i am a shell command
+\`\`\`
+"
+`;

--- a/tests/electron-lint-markdown-standard.spec.ts
+++ b/tests/electron-lint-markdown-standard.spec.ts
@@ -1,0 +1,111 @@
+import * as cp from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const FIXTURES_DIR = path.resolve(__dirname, 'fixtures');
+
+function runLintMarkdownStandard(...args: string[]) {
+  return cp.spawnSync(
+    process.execPath,
+    [path.resolve(__dirname, '../dist/bin/lint-markdown-standard.js'), ...args],
+    { stdio: 'pipe', encoding: 'utf-8' },
+  );
+}
+
+describe('electron-lint-markdown-standard', () => {
+  it('requires --root', () => {
+    const { status, stdout } = runLintMarkdownStandard('broken-internal-link.md');
+
+    expect(stdout).toContain('Usage');
+    expect(status).toEqual(1);
+  });
+
+  it('should run clean when there are no errors', () => {
+    const { status } = runLintMarkdownStandard('--root', FIXTURES_DIR, 'clean.md');
+
+    expect(status).toEqual(0);
+  });
+
+  it('can ignore a glob', () => {
+    const { status } = runLintMarkdownStandard(
+      '--root',
+      FIXTURES_DIR,
+      '--ignore',
+      '**/dirty.md',
+      '{clean,dirty}.md',
+    );
+
+    expect(status).toEqual(0);
+  });
+
+  it('can ignore multiple globs', () => {
+    const { status } = runLintMarkdownStandard(
+      '--root',
+      FIXTURES_DIR,
+      '--ignore',
+      '**/cleanable.md',
+      '--ignore',
+      '**/dirty.md',
+      '*.md',
+    );
+
+    expect(status).toEqual(0);
+  });
+
+  it('can ignore from a file', () => {
+    const { status } = runLintMarkdownStandard(
+      '--root',
+      FIXTURES_DIR,
+      '--ignore-path',
+      path.resolve(FIXTURES_DIR, 'ignorepaths'),
+      '{clean,cleanable,dirty}.md',
+    );
+
+    expect(status).toEqual(0);
+  });
+
+  it('can detect errors in code blocks', () => {
+    const { status, stdout } = runLintMarkdownStandard('--root', FIXTURES_DIR, 'dirty.md');
+
+    expect(stdout.replace(FIXTURES_DIR, '<root>')).toMatchSnapshot();
+    expect(status).toEqual(1);
+  });
+
+  it('can fix cleanable errors with --fix option', async () => {
+    const tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), 'lint-roller-'));
+    fs.copyFile(path.join(FIXTURES_DIR, 'cleanable.md'), path.join(tmpdir, 'cleanable.md'));
+
+    try {
+      const { status, stdout } = runLintMarkdownStandard('--fix', '--root', tmpdir, 'cleanable.md');
+
+      expect(
+        await fs.readFile(path.join(tmpdir, 'cleanable.md'), { encoding: 'utf-8' }),
+      ).toMatchSnapshot();
+      expect(stdout).toContain('File has changed: cleanable.md');
+      expect(stdout).toContain('There are 0 errors');
+      expect(status).toEqual(0);
+    } finally {
+      await fs.rm(tmpdir, { recursive: true, force: true });
+    }
+  });
+
+  it('outputs uncleanable errors with --fix option', async () => {
+    const tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), 'lint-roller-'));
+    fs.copyFile(path.join(FIXTURES_DIR, 'dirty.md'), path.join(tmpdir, 'dirty.md'));
+
+    try {
+      const { status, stdout } = runLintMarkdownStandard('--fix', '--root', tmpdir, 'dirty.md');
+
+      expect(
+        await fs.readFile(path.join(tmpdir, 'dirty.md'), { encoding: 'utf-8' }),
+      ).toMatchSnapshot();
+      expect(stdout).toContain('File has changed: dirty.md');
+      expect(stdout).toContain("Expected '===' and instead saw '=='");
+      expect(stdout).toContain('There are 3 errors');
+      expect(status).toEqual(1);
+    } finally {
+      await fs.rm(tmpdir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/fixtures/clean.md
+++ b/tests/fixtures/clean.md
@@ -1,0 +1,72 @@
+# The Clean Readme
+
+This is a markdown file with some javascript code blocks in it.
+
+```js
+console.log('all good here!')
+```
+
+There are no linting errors in this file.
+
+```javascript
+const wibble = 2
+console.log(wibble)
+```
+
+It should allow use of undefined variables
+
+```javascript
+win.close()
+```
+
+It should allow creation of unused variables
+
+```js
+// `BrowserWindow` is declared but not used
+const { BrowserWindow } = require('electron')
+```
+
+It should allow orphan objects:
+
+```js
+{ some: 'object' }
+```
+
+and this wrapping kind too:
+
+```js
+{
+  some: 'object',
+  with: 'different whitespace and tabbing'
+}
+```
+
+and arrays:
+
+```js
+[1, 2, 3]
+```
+
+and wrapped arrays:
+
+```js
+[
+  4,
+  5,
+  6
+]
+```
+
+Electron docs have a bunch of non-node-style callbacks that don't have `err` as the first arg:
+
+```javascript
+const { app } = require('electron')
+
+app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
+  if (url === 'https://github.com') {
+    callback(true)
+  } else {
+    callback(false)
+  }
+})
+```

--- a/tests/fixtures/cleanable.md
+++ b/tests/fixtures/cleanable.md
@@ -1,0 +1,66 @@
+# The Cleanable Readme
+
+This is a markdown file with some javascript code blocks in it.
+
+```js
+var foo = 1;
+```
+
+Each block is parsed separately, to avoid linting errors about variable
+assignment. Notice that `var foo` occurs twice in this markdown file,
+but only once in each individual snippet.
+
+The following code block has a few issues:
+
+- semicolons
+- type-insensitive equality comparison
+- double-quoted string
+
+```javascript
+var foo = 2;
+console.log("foo is two");
+```
+
+Same as before, but with metadata:
+
+```javascript title='main.js'
+var foo = 2;
+console.log("foo is two");
+```
+
+This non-js code block should be ignored by the cleaner and the linter:
+
+```sh
+echo i am a shell command
+```
+
+It should allow orphan objects:
+
+```js
+{some: 'object'}
+```
+
+and this wrapping kind too:
+
+```js
+{
+  some: 'object',
+  with: 'different whitespace and tabbing'
+}
+```
+
+and arrays:
+
+```js
+[1,2,3]
+```
+
+and wrapped arrays:
+
+```js
+[
+  4,
+  5,
+  6,
+]
+```

--- a/tests/fixtures/dirty.md
+++ b/tests/fixtures/dirty.md
@@ -1,0 +1,41 @@
+# The Dirty Readme
+
+This is a markdown file with some javascript code blocks in it.
+
+```js
+var foo = 1;
+```
+
+Each block is parsed separately, to avoid linting errors about variable
+assignment. Notice that `var foo` occurs twice in this markdown file,
+but only once in each individual snippet.
+
+The following code block has a few issues:
+
+- semicolons
+- type-insensitive equality comparison
+- double-quoted string
+
+```javascript
+var foo = 2;
+if (foo == 1) console.log("foo is one");
+```
+
+Same as before, but with metadata:
+
+```javascript title='main.js'
+var foo = 2;
+if (foo == 1) console.log("foo is one");
+```
+
+Blocks should have lowercase language identifiers:
+
+```JavaScript
+var foo = 3;
+```
+
+This non-js code block should be ignored by the linter:
+
+```sh
+echo i am a shell command
+```

--- a/tests/fixtures/ignorepaths
+++ b/tests/fixtures/ignorepaths
@@ -1,3 +1,5 @@
 **/broken-{external,internal}-link.md
 **/broken-cross-file-link.md
 **/valid-cross-file-link.md
+**/cleanable.md
+**/dirty.md

--- a/yarn.lock
+++ b/yarn.lock
@@ -354,6 +354,18 @@
     eslint-plugin-node "^11.1.0"
     eslint-plugin-promise "^5.1.1"
 
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
+  integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
+  dependencies:
+    eslint-visitor-keys "^3.3.0"
+
+"@eslint-community/regexpp@^4.4.0":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.1.tgz#cdd35dce4fa1a89a4fd42b1599eb35b3af408884"
+  integrity sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==
+
 "@eslint/eslintrc@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz#af58772019a2d271b7e2d4c23ff4ddcba3ccfb3e"
@@ -368,6 +380,26 @@
     js-yaml "^4.1.0"
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
+
+"@eslint/eslintrc@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.0.2.tgz#01575e38707add677cf73ca1589abba8da899a02"
+  integrity sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.3.2"
+    espree "^9.5.1"
+    globals "^13.19.0"
+    ignore "^5.2.0"
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    minimatch "^3.1.2"
+    strip-json-comments "^3.1.1"
+
+"@eslint/js@8.39.0":
+  version "8.39.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.39.0.tgz#58b536bcc843f4cd1e02a7e6171da5c040f4d44b"
+  integrity sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==
 
 "@gar/promisify@^1.1.3":
   version "1.1.3"
@@ -1257,7 +1289,7 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-array-includes@^3.1.6:
+array-includes@^3.1.5, array-includes@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.6.tgz#9e9e720e194f198266ba9e18c29e6a9b0e4b225f"
   integrity sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==
@@ -1292,6 +1324,17 @@ array.prototype.flatmap@^1.3.1:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
+
+array.prototype.tosorted@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz#ccf44738aa2b5ac56578ffda97c03fd3e23dd532"
+  integrity sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    es-shim-unscopables "^1.0.0"
+    get-intrinsic "^1.1.3"
 
 asap@^2.0.0:
   version "2.0.6"
@@ -1449,7 +1492,7 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-builtins@^5.0.0:
+builtins@^5.0.0, builtins@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-5.0.1.tgz#87f6db9ab0458be728564fa81d876d8d74552fa9"
   integrity sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==
@@ -1975,6 +2018,16 @@ eslint-config-prettier@^8.6.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz#dec1d29ab728f4fa63061774e1672ac4e363d207"
   integrity sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==
 
+eslint-config-standard-jsx@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-11.0.0.tgz#70852d395731a96704a592be5b0bfaccfeded239"
+  integrity sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==
+
+eslint-config-standard@17.0.0:
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz#fd5b6cf1dcf6ba8d29f200c461de2e19069888cf"
+  integrity sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==
+
 eslint-config-standard@^16.0.3:
   version "16.0.3"
   resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz#6c8761e544e96c531ff92642eeb87842b8488516"
@@ -2004,7 +2057,15 @@ eslint-plugin-es@^3.0.0:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
 
-eslint-plugin-import@^2.25.2:
+eslint-plugin-es@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz#f0822f0c18a535a97c3e714e89f88586a7641ec9"
+  integrity sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==
+  dependencies:
+    eslint-utils "^2.0.0"
+    regexpp "^3.0.0"
+
+eslint-plugin-import@^2.25.2, eslint-plugin-import@^2.26.0:
   version "2.27.5"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz#876a6d03f52608a3e5bb439c2550588e51dd6c65"
   integrity sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==
@@ -2025,6 +2086,20 @@ eslint-plugin-import@^2.25.2:
     semver "^6.3.0"
     tsconfig-paths "^3.14.1"
 
+eslint-plugin-n@^15.1.0:
+  version "15.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz#e29221d8f5174f84d18f2eb94765f2eeea033b90"
+  integrity sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==
+  dependencies:
+    builtins "^5.0.1"
+    eslint-plugin-es "^4.1.0"
+    eslint-utils "^3.0.0"
+    ignore "^5.1.1"
+    is-core-module "^2.11.0"
+    minimatch "^3.1.2"
+    resolve "^1.22.1"
+    semver "^7.3.8"
+
 eslint-plugin-node@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"
@@ -2042,6 +2117,32 @@ eslint-plugin-promise@^5.1.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz#a596acc32981627eb36d9d75f9666ac1a4564971"
   integrity sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==
 
+eslint-plugin-promise@^6.0.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz#269a3e2772f62875661220631bd4dafcb4083816"
+  integrity sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==
+
+eslint-plugin-react@^7.28.0:
+  version "7.32.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz#e71f21c7c265ebce01bcbc9d0955170c55571f10"
+  integrity sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==
+  dependencies:
+    array-includes "^3.1.6"
+    array.prototype.flatmap "^1.3.1"
+    array.prototype.tosorted "^1.1.1"
+    doctrine "^2.1.0"
+    estraverse "^5.3.0"
+    jsx-ast-utils "^2.4.1 || ^3.0.0"
+    minimatch "^3.1.2"
+    object.entries "^1.1.6"
+    object.fromentries "^2.0.6"
+    object.hasown "^1.1.2"
+    object.values "^1.1.6"
+    prop-types "^15.8.1"
+    resolve "^2.0.0-next.4"
+    semver "^6.3.0"
+    string.prototype.matchall "^4.0.8"
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -2054,6 +2155,14 @@ eslint-scope@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
   integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
+
+eslint-scope@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.0.tgz#f21ebdafda02352f103634b96dd47d9f81ca117b"
+  integrity sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
@@ -2086,6 +2195,57 @@ eslint-visitor-keys@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
+
+eslint-visitor-keys@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz#c7f0f956124ce677047ddbc192a68f999454dedc"
+  integrity sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==
+
+eslint@^8.13.0:
+  version "8.39.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.39.0.tgz#7fd20a295ef92d43809e914b70c39fd5a23cf3f1"
+  integrity sha512-mwiok6cy7KTW7rBpo05k6+p4YVZByLNjAZ/ACB9DRCu4YDRwjXI01tWHp6KAUWelsBetTxKK/2sHB0vdS8Z2Og==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@eslint-community/regexpp" "^4.4.0"
+    "@eslint/eslintrc" "^2.0.2"
+    "@eslint/js" "8.39.0"
+    "@humanwhocodes/config-array" "^0.11.8"
+    "@humanwhocodes/module-importer" "^1.0.1"
+    "@nodelib/fs.walk" "^1.2.8"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.3.2"
+    doctrine "^3.0.0"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^7.2.0"
+    eslint-visitor-keys "^3.4.0"
+    espree "^9.5.1"
+    esquery "^1.4.2"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    find-up "^5.0.0"
+    glob-parent "^6.0.2"
+    globals "^13.19.0"
+    grapheme-splitter "^1.0.4"
+    ignore "^5.2.0"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    is-path-inside "^3.0.3"
+    js-sdsl "^4.1.4"
+    js-yaml "^4.1.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.1.2"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    strip-ansi "^6.0.1"
+    strip-json-comments "^3.1.0"
+    text-table "^0.2.0"
 
 eslint@^8.34.0:
   version "8.34.0"
@@ -2141,6 +2301,15 @@ espree@^9.4.0:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.3.0"
 
+espree@^9.5.1:
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.5.1.tgz#4f26a4d5f18905bf4f2e0bd99002aab807e96dd4"
+  integrity sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==
+  dependencies:
+    acorn "^8.8.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.4.0"
+
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
@@ -2150,6 +2319,13 @@ esquery@^1.4.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.2.tgz#c6d3fee05dd665808e2ad870631f221f5617b1d1"
   integrity sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==
+  dependencies:
+    estraverse "^5.1.0"
+
+esquery@^1.4.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
+  integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
   dependencies:
     estraverse "^5.1.0"
 
@@ -2165,7 +2341,7 @@ estraverse@^4.1.1:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -2264,6 +2440,13 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
 
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
@@ -2408,6 +2591,11 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
+get-stdin@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
+  integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
+
 get-stdin@~9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-9.0.0.tgz#3983ff82e03d56f1b2ea0d3e60325f39d703a575"
@@ -2511,6 +2699,11 @@ gopd@^1.0.1:
   integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
   dependencies:
     get-intrinsic "^1.1.3"
+
+graceful-fs@^4.1.15:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"
@@ -2710,7 +2903,7 @@ init-package-json@^3.0.2:
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^4.0.0"
 
-internal-slot@^1.0.4:
+internal-slot@^1.0.3, internal-slot@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.5.tgz#f2a2ee21f668f8627a4667f309dc0f4fb6674986"
   integrity sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==
@@ -3303,7 +3496,7 @@ js-sdsl@^4.1.4:
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.3.0.tgz#aeefe32a451f7af88425b11fdb5f58c90ae1d711"
   integrity sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==
 
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -3327,6 +3520,11 @@ jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
 json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
   version "2.3.1"
@@ -3378,6 +3576,14 @@ jsonparse@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
+
+"jsx-ast-utils@^2.4.1 || ^3.0.0":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz#76b3e6e6cece5c69d49a5792c3d01bd1a0cdc7ea"
+  integrity sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==
+  dependencies:
+    array-includes "^3.1.5"
+    object.assign "^4.1.3"
 
 just-diff-apply@^5.2.0:
   version "5.5.0"
@@ -3537,6 +3743,25 @@ linkify-it@^4.0.1:
   dependencies:
     uc.micro "^1.0.1"
 
+load-json-file@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-5.3.0.tgz#4d3c1e01fa1c03ea78a60ac7af932c9ce53403f3"
+  integrity sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==
+  dependencies:
+    graceful-fs "^4.1.15"
+    parse-json "^4.0.0"
+    pify "^4.0.1"
+    strip-bom "^3.0.0"
+    type-fest "^0.3.0"
+
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -3565,6 +3790,13 @@ lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -4319,6 +4551,11 @@ npmlog@^6.0.0, npmlog@^6.0.2:
     gauge "^4.0.3"
     set-blocking "^2.0.0"
 
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
 object-inspect@^1.12.2, object-inspect@^1.9.0:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
@@ -4329,7 +4566,7 @@ object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object.assign@^4.1.4:
+object.assign@^4.1.3, object.assign@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
   integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
@@ -4338,6 +4575,32 @@ object.assign@^4.1.4:
     define-properties "^1.1.4"
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
+
+object.entries@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.6.tgz#9737d0e5b8291edd340a3e3264bb8a3b00d5fa23"
+  integrity sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
+object.fromentries@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.6.tgz#cdb04da08c539cffa912dcd368b886e0904bfa73"
+  integrity sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
+object.hasown@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/object.hasown/-/object.hasown-1.1.2.tgz#f919e21fad4eb38a57bc6345b3afd496515c3f92"
+  integrity sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==
+  dependencies:
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
 
 object.values@^1.1.6:
   version "1.1.6"
@@ -4379,7 +4642,7 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
-p-limit@^2.2.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -4392,6 +4655,13 @@ p-limit@^3.0.2, p-limit@^3.1.0:
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -4462,6 +4732,14 @@ parse-conflict-json@^2.0.1, parse-conflict-json@^2.0.2:
     just-diff "^5.0.1"
     just-diff-apply "^5.2.0"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
 parse-json@^5.0.0, parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
@@ -4471,6 +4749,11 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+  integrity sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -4507,10 +4790,23 @@ picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
 pirates@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
   integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
+
+pkg-conf@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-conf/-/pkg-conf-3.1.0.tgz#d9f9c75ea1bae0e77938cde045b276dac7cc69ae"
+  integrity sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==
+  dependencies:
+    find-up "^3.0.0"
+    load-json-file "^5.2.0"
 
 pkg-dir@^4.2.0:
   version "4.2.0"
@@ -4589,6 +4885,15 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
+prop-types@^15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 punycode@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
@@ -4613,6 +4918,11 @@ rc@1.2.8, rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-is@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-is@^18.0.0:
   version "18.2.0"
@@ -4735,6 +5045,15 @@ resolve@^1.10.0, resolve@^1.10.1, resolve@^1.20.0, resolve@^1.22.1:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+resolve@^2.0.0-next.4:
+  version "2.0.0-next.4"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.4.tgz#3d37a113d6429f496ec4752d2a2e58efb1fd4660"
+  integrity sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
@@ -4811,6 +5130,13 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.8:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.0.tgz#ed8c5dc8efb6c629c88b23d41dc9bf40c1d96cd0"
+  integrity sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==
+  dependencies:
+    lru-cache "^6.0.0"
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -4933,6 +5259,30 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+standard-engine@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/standard-engine/-/standard-engine-15.0.0.tgz#e37ca2e1a589ef85431043a3e87cb9ce95a4ca4e"
+  integrity sha512-4xwUhJNo1g/L2cleysUqUv7/btn7GEbYJvmgKrQ2vd/8pkTmN8cpqAZg+BT8Z1hNeEH787iWUdOpL8fmApLtxA==
+  dependencies:
+    get-stdin "^8.0.0"
+    minimist "^1.2.6"
+    pkg-conf "^3.1.0"
+    xdg-basedir "^4.0.0"
+
+standard@^17.0.0:
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/standard/-/standard-17.0.0.tgz#85718ecd04dc4133908434660788708cca855aa1"
+  integrity sha512-GlCM9nzbLUkr+TYR5I2WQoIah4wHA2lMauqbyPLV/oI5gJxqhHzhjl9EG2N0lr/nRqI3KCbCvm/W3smxvLaChA==
+  dependencies:
+    eslint "^8.13.0"
+    eslint-config-standard "17.0.0"
+    eslint-config-standard-jsx "^11.0.0"
+    eslint-plugin-import "^2.26.0"
+    eslint-plugin-n "^15.1.0"
+    eslint-plugin-promise "^6.0.0"
+    eslint-plugin-react "^7.28.0"
+    standard-engine "^15.0.0"
+
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
@@ -4949,6 +5299,20 @@ string-length@^4.0.1:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string.prototype.matchall@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz#3bf85722021816dcd1bf38bb714915887ca79fd3"
+  integrity sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    get-intrinsic "^1.1.3"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.3"
+    regexp.prototype.flags "^1.4.3"
+    side-channel "^1.0.4"
 
 string.prototype.trimend@^1.0.6:
   version "1.0.6"
@@ -5169,6 +5533,11 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
+  integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
 
 type-fest@^0.6.0:
   version "0.6.0"
@@ -5443,6 +5812,11 @@ write-file-atomic@^4.0.0, write-file-atomic@^4.0.1, write-file-atomic@^4.0.2:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
+
+xdg-basedir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
+  integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
Effectively recreates [`zeke/standard-markdown`](https://github.com/zeke/standard-markdown) inside this project. A couple of small pieces of code (`removeParensWrappingOrphanedObject`, `wrapOrphanObjectInParens`) are taken from there, and the test fixtures are from that project, with more test cases added.

Why? That project is not currently maintained (CI is non-operational), and the regexes to find code blocks are unfortunately not very robust. Things like spaces after the backticks, camelCase, an info string (text after the language identifier), etc will cause code blocks to be skipped in `standard-markdown`. This has become problematic in Electron since much of the docs uses code blocks with info strings for rich rendering on the website, causing many blocks to not be linted currently (see https://github.com/electron/electron/issues/38024).

Since the implementation in this PR uses a Markdown parser to locate the blocks, it will be robust to the variations in code block syntax. It also provides easy access to the info string so future PRs may add more robust linting functionality by making use of that (such as declaring globals, or changing the disabled ESLint rules).

Main differences from `standard-markdown`:
* Uses `standard@^17.0.0`
* Adds an error if the language identifier on the code block is not all lowercase