### PR TITLE
fix: maintain indentation for code blocks

### DIFF
--- a/tests/__snapshots__/electron-lint-markdown-standard.spec.ts.snap
+++ b/tests/__snapshots__/electron-lint-markdown-standard.spec.ts.snap
@@ -15,11 +15,16 @@ exports[`electron-lint-markdown-standard can detect errors in code blocks 1`] = 
          28:9:     Expected '===' and instead saw '=='.
          28:27:    Strings must use singlequote.
          28:40:    Extra semicolon.
-         33:1:     Code block language identifier should be all lowercase
-         34:1:     Unexpected var, use let or const instead.
-         34:12:    Extra semicolon.
+         34:4:     Unexpected var, use let or const instead.
+         34:15:    Extra semicolon.
+         35:12:    Expected '===' and instead saw '=='.
+         35:30:    Strings must use singlequote.
+         35:43:    Extra semicolon.
+         40:1:     Code block language identifier should be all lowercase
+         41:1:     Unexpected var, use let or const instead.
+         41:12:    Extra semicolon.
 
-There are 15 errors in '<root>'
+There are 20 errors in '<root>'
 "
 `;
 
@@ -53,6 +58,13 @@ Same as before, but with metadata:
 const foo = 2
 console.log('foo is two')
 \`\`\`
+
+1. Same as before, but indented
+
+   \`\`\`javascript title='main.js'
+   const foo = 2
+   console.log('foo is two')
+   \`\`\`
 
 This non-js code block should be ignored by the cleaner and the linter:
 
@@ -123,6 +135,13 @@ Same as before, but with metadata:
 const foo = 2
 if (foo == 1) console.log('foo is one')
 \`\`\`
+
+1. Same as before, but indented
+
+   \`\`\`javascript title='main.js'
+   const foo = 2
+   if (foo == 1) console.log('foo is one')
+   \`\`\`
 
 Blocks should have lowercase language identifiers:
 

--- a/tests/electron-lint-markdown-standard.spec.ts
+++ b/tests/electron-lint-markdown-standard.spec.ts
@@ -102,7 +102,7 @@ describe('electron-lint-markdown-standard', () => {
       ).toMatchSnapshot();
       expect(stdout).toContain('File has changed: dirty.md');
       expect(stdout).toContain("Expected '===' and instead saw '=='");
-      expect(stdout).toContain('There are 3 errors');
+      expect(stdout).toContain('There are 4 errors');
       expect(status).toEqual(1);
     } finally {
       await fs.rm(tmpdir, { recursive: true, force: true });

--- a/tests/fixtures/clean.md
+++ b/tests/fixtures/clean.md
@@ -70,3 +70,9 @@ app.on('certificate-error', (event, webContents, url, error, certificate, callba
   }
 })
 ```
+
+1. Indented code
+
+   ```js
+   console.log('all good here!')
+   ```

--- a/tests/fixtures/cleanable.md
+++ b/tests/fixtures/cleanable.md
@@ -28,6 +28,13 @@ var foo = 2;
 console.log("foo is two");
 ```
 
+1. Same as before, but indented
+
+   ```javascript title='main.js'
+   var foo = 2;
+   console.log("foo is two");
+   ```
+
 This non-js code block should be ignored by the cleaner and the linter:
 
 ```sh

--- a/tests/fixtures/dirty.md
+++ b/tests/fixtures/dirty.md
@@ -28,6 +28,13 @@ var foo = 2;
 if (foo == 1) console.log("foo is one");
 ```
 
+1. Same as before, but indented
+
+   ```javascript title='main.js'
+   var foo = 2;
+   if (foo == 1) console.log("foo is one");
+   ```
+
 Blocks should have lowercase language identifiers:
 
 ```JavaScript


### PR DESCRIPTION
Current implementation is stripping indentation inside of the code block, which is not correct.