### PR TITLE
fix: properly handle multiple @ts-ignore lines

### DIFF
--- a/tests/__snapshots__/electron-lint-markdown-ts-check.spec.ts.snap
+++ b/tests/__snapshots__/electron-lint-markdown-ts-check.spec.ts.snap
@@ -23,14 +23,20 @@ ts-check.md:43:1: Code block has both @ts-nocheck and @ts-ignore, they conflict
 [7m8[0m console.foo('whoops')
 [7m [0m [91m        ~~~[0m
 
+[96mts-check.md[0m:[93m83[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'myAwesomeAPI' does not exist on type 'Window & typeof globalThis'.
 
-Found 4 errors in 4 files.
+[7m83[0m window.myAwesomeAPI()
+[7m  [0m [91m       ~~~~~~~~~~~~[0m
+
+
+Found 5 errors in 5 files.
 
 Errors  Files
      1  ts-check.md[90m:4[0m
      1  ts-check.md[90m:54[0m
      1  ts-check.md[90m:60[0m
      1  ts-check.md[90m:8[0m
+     1  ts-check.md[90m:83[0m
 
 "
 `;

--- a/tests/fixtures/ts-check.md
+++ b/tests/fixtures/ts-check.md
@@ -59,3 +59,27 @@ const { BrowserWindow } = require('electron')
 
 BrowserWindow.wrongAPI('foo')
 ```
+
+These blocks have multiple @ts-ignore lines
+
+```js @ts-ignore=[3,5]
+console.log('test')
+
+window.myAwesomeAPI()
+
+window.myOtherAwesomeAPI()
+```
+
+```js @ts-ignore=[1,4]
+window.myAwesomeAPI()
+
+console.log('test')
+window.myOtherAwesomeAPI()
+```
+
+This confirms @ts-ignore output is stripped
+
+```js @ts-ignore=[2]
+window.myAwesomeAPI()
+window.myOtherAwesomeAPI()
+```


### PR DESCRIPTION
Flubbed the original implementation. This fix ensures that the line numbers in the `tsc` output are accurate, and that multiple `@ts-ignore` lines refer to the correct line.