### PR TITLE
fix: add more modules for type checking

### DIFF
--- a/bin/lint-markdown-ts-check.ts
+++ b/bin/lint-markdown-ts-check.ts
@@ -33,10 +33,12 @@ const ELECTRON_MODULES = [
   'systemPreferences',
   'Tray',
   'utilityProcess',
+  'webFrame',
   'webFrameMain',
 ];
 
-const NODE_IMPORTS = "const fs = require('node:fs'); const path = require('node:path')";
+const NODE_IMPORTS =
+  "const childProcess = require('node:child_process'); const fs = require('node:fs'); const path = require('node:path')";
 
 const DEFAULT_IMPORTS = `${NODE_IMPORTS}; const { ${ELECTRON_MODULES.join(
   ', ',


### PR DESCRIPTION
Need a couple more modules for a clean lint run on `e/e`.