### PR TITLE
fix: replace previous line comment when inserting ts-ignore

### DIFF
--- a/bin/lint-markdown-ts-check.ts
+++ b/bin/lint-markdown-ts-check.ts
@@ -115,7 +115,14 @@ async function main(workspaceRoot: string, globs: string[], { ignoreGlobs = [] }
             firstLineIsTsIgnore = true;
           } else {
             const offset = firstLineIsTsIgnore ? 1 : 2;
-            codeLines[line - offset] = `${codeLines[line - offset]} // @ts-ignore`;
+            const codeLine = codeLines[line - offset];
+            // If the line is already a comment, fully replace it,
+            // otherwise tsc won't pick up the @ts-ignore comment
+            if (codeLine.match(/^\s*\/\/\s/)) {
+              codeLines[line - offset] = '// @ts-ignore';
+            } else {
+              codeLines[line - offset] = `${codeLine} // @ts-ignore`;
+            }
           }
         }
 

--- a/tests/fixtures/ts-check.md
+++ b/tests/fixtures/ts-check.md
@@ -83,3 +83,12 @@ This confirms @ts-ignore output is stripped
 window.myAwesomeAPI()
 window.myOtherAwesomeAPI()
 ```
+
+This confirms @ts-ignore works if the previous line is a comment
+
+```js @ts-ignore=[4]
+console.log('test')
+
+// This is a comment
+window.myAwesomeAPI()
+```


### PR DESCRIPTION
Prevents situations where the modified line ends up being `// comment // @ts-ignore` which `tsc` wouldn't pick up.