### PR TITLE
feat: ts-type for type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ detection of code blocks.
 
 `electron-lint-markdown-ts-check` is a command to type check JS code blocks in
 Markdown with `tsc`. Type checking can be disabled for specific code blocks
-by adding `@ts-nocheck` to the info string, and specific lines can be ignored
-by adding `@ts-ignore=[<line1>,<line2>]` to the info string.
+by adding `@ts-nocheck` to the info string, specific lines can be ignored
+by adding `@ts-ignore=[<line1>,<line2>]` to the info string, and additional
+globals can be defined with `@ts-type={name:type}`.
 
 ## License
 

--- a/tests/__snapshots__/electron-lint-markdown-ts-check.spec.ts.snap
+++ b/tests/__snapshots__/electron-lint-markdown-ts-check.spec.ts.snap
@@ -1,8 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`electron-lint-markdown-ts-check should type check code blocks 1`] = `
-"ts-check.md:37:1: Code block has both @ts-nocheck and @ts-ignore, they conflict
-ts-check.md:43:1: Code block has both @ts-nocheck and @ts-ignore, they conflict
+"ts-check.md:37:1: Code block has both @ts-nocheck and @ts-ignore/@ts-type, they conflict
+ts-check.md:43:1: Code block has both @ts-nocheck and @ts-ignore/@ts-type, they conflict
+[96mts-check.md[0m:[93m109[0m:[93m5[0m - [91merror[0m[90m TS2304: [0mCannot find name 'a'.
+
+[7m109[0m if (a > b) {
+[7m   [0m [91m    ~[0m
+
+[96mts-check.md[0m:[93m109[0m:[93m9[0m - [91merror[0m[90m TS2304: [0mCannot find name 'b'.
+
+[7m109[0m if (a > b) {
+[7m   [0m [91m        ~[0m
+
+[96mts-check.md[0m:[93m112[0m:[93m28[0m - [91merror[0m[90m TS2304: [0mCannot find name 'a'.
+
+[7m112[0m   console.log(\`not true: \${a} < \${b}\`)
+[7m   [0m [91m                           ~[0m
+
+[96mts-check.md[0m:[93m112[0m:[93m35[0m - [91merror[0m[90m TS2304: [0mCannot find name 'b'.
+
+[7m112[0m   console.log(\`not true: \${a} < \${b}\`)
+[7m   [0m [91m                                  ~[0m
+
 [96mts-check.md[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2339: [0mProperty 'foo' does not exist on type 'Console'.
 
 [7m4[0m console.foo('whoops')
@@ -29,9 +49,10 @@ ts-check.md:43:1: Code block has both @ts-nocheck and @ts-ignore, they conflict
 [7m  [0m [91m       ~~~~~~~~~~~~[0m
 
 
-Found 5 errors in 5 files.
+Found 9 errors in 6 files.
 
 Errors  Files
+     4  ts-check.md[90m:109[0m
      1  ts-check.md[90m:4[0m
      1  ts-check.md[90m:54[0m
      1  ts-check.md[90m:60[0m

--- a/tests/fixtures/ts-check.md
+++ b/tests/fixtures/ts-check.md
@@ -92,3 +92,23 @@ console.log('test')
 // This is a comment
 window.myAwesomeAPI()
 ```
+
+This block defines additional types
+
+```js @ts-type={a: number} @ts-type={debug: (url: string) => boolean} @ts-type={b: number}
+if (a > b) {
+  debug('true')
+} else {
+  debug(`not true: ${a} < ${b}`)
+}
+```
+
+This block has undefined variables
+
+```js
+if (a > b) {
+  console.log('true')
+} else {
+  console.log(`not true: ${a} < ${b}`)
+}
+```


### PR DESCRIPTION
Sometimes the code blocks in the Electron docs are snippets which use variables not defined in that snippet, and sometimes it would be too cluttered/repetitive to define them in each snippet. This change allows for those variables to be typed with `@ts-type={name:type}` without needing to initialize them, since they're only used for type checking.