### PR TITLE
feat: support ts-expect-error for type checking

### DIFF
--- a/tests/__snapshots__/electron-lint-markdown-ts-check.spec.ts.snap
+++ b/tests/__snapshots__/electron-lint-markdown-ts-check.spec.ts.snap
@@ -1,26 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`electron-lint-markdown-ts-check should type check code blocks 1`] = `
-"ts-check.md:37:1: Code block has both @ts-nocheck and @ts-ignore/@ts-type, they conflict
-ts-check.md:43:1: Code block has both @ts-nocheck and @ts-ignore/@ts-type, they conflict
-[96mts-check.md[0m:[93m109[0m:[93m5[0m - [91merror[0m[90m TS2304: [0mCannot find name 'a'.
+"ts-check.md:49:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignore/@ts-type, they conflict
+ts-check.md:55:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignore/@ts-type, they conflict
+[96mts-check.md[0m:[93m128[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'myAwesomeAPI' does not exist on type 'Window & typeof globalThis'.
 
-[7m109[0m if (a > b) {
+[7m128[0m window.myAwesomeAPI()
+[7m   [0m [91m       ~~~~~~~~~~~~[0m
+
+[96mts-check.md[0m:[93m154[0m:[93m5[0m - [91merror[0m[90m TS2304: [0mCannot find name 'a'.
+
+[7m154[0m if (a > b) {
 [7m   [0m [91m    ~[0m
 
-[96mts-check.md[0m:[93m109[0m:[93m9[0m - [91merror[0m[90m TS2304: [0mCannot find name 'b'.
+[96mts-check.md[0m:[93m154[0m:[93m9[0m - [91merror[0m[90m TS2304: [0mCannot find name 'b'.
 
-[7m109[0m if (a > b) {
+[7m154[0m if (a > b) {
 [7m   [0m [91m        ~[0m
 
-[96mts-check.md[0m:[93m112[0m:[93m28[0m - [91merror[0m[90m TS2304: [0mCannot find name 'a'.
+[96mts-check.md[0m:[93m157[0m:[93m28[0m - [91merror[0m[90m TS2304: [0mCannot find name 'a'.
 
-[7m112[0m   console.log(\`not true: \${a} < \${b}\`)
+[7m157[0m   console.log(\`not true: \${a} < \${b}\`)
 [7m   [0m [91m                           ~[0m
 
-[96mts-check.md[0m:[93m112[0m:[93m35[0m - [91merror[0m[90m TS2304: [0mCannot find name 'b'.
+[96mts-check.md[0m:[93m157[0m:[93m35[0m - [91merror[0m[90m TS2304: [0mCannot find name 'b'.
 
-[7m112[0m   console.log(\`not true: \${a} < \${b}\`)
+[7m157[0m   console.log(\`not true: \${a} < \${b}\`)
 [7m   [0m [91m                                  ~[0m
 
 [96mts-check.md[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2339: [0mProperty 'foo' does not exist on type 'Console'.
@@ -28,14 +33,14 @@ ts-check.md:43:1: Code block has both @ts-nocheck and @ts-ignore/@ts-type, they 
 [7m4[0m console.foo('whoops')
 [7m [0m [91m        ~~~[0m
 
-[96mts-check.md[0m:[93m54[0m:[93m15[0m - [91merror[0m[90m TS2339: [0mProperty 'wrongAPI' does not exist on type 'typeof BrowserWindow'.
+[96mts-check.md[0m:[93m66[0m:[93m15[0m - [91merror[0m[90m TS2339: [0mProperty 'wrongAPI' does not exist on type 'typeof BrowserWindow'.
 
-[7m54[0m BrowserWindow.wrongAPI('foo')
+[7m66[0m BrowserWindow.wrongAPI('foo')
 [7m  [0m [91m              ~~~~~~~~[0m
 
-[96mts-check.md[0m:[93m60[0m:[93m15[0m - [91merror[0m[90m TS2339: [0mProperty 'wrongAPI' does not exist on type 'typeof BrowserWindow'.
+[96mts-check.md[0m:[93m72[0m:[93m15[0m - [91merror[0m[90m TS2339: [0mProperty 'wrongAPI' does not exist on type 'typeof BrowserWindow'.
 
-[7m60[0m BrowserWindow.wrongAPI('foo')
+[7m72[0m BrowserWindow.wrongAPI('foo')
 [7m  [0m [91m              ~~~~~~~~[0m
 
 [96mts-check.md[0m:[93m8[0m:[93m9[0m - [91merror[0m[90m TS2339: [0mProperty 'foo' does not exist on type 'Console'.
@@ -43,21 +48,22 @@ ts-check.md:43:1: Code block has both @ts-nocheck and @ts-ignore/@ts-type, they 
 [7m8[0m console.foo('whoops')
 [7m [0m [91m        ~~~[0m
 
-[96mts-check.md[0m:[93m83[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'myAwesomeAPI' does not exist on type 'Window & typeof globalThis'.
+[96mts-check.md[0m:[93m95[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'myAwesomeAPI' does not exist on type 'Window & typeof globalThis'.
 
-[7m83[0m window.myAwesomeAPI()
+[7m95[0m window.myAwesomeAPI()
 [7m  [0m [91m       ~~~~~~~~~~~~[0m
 
 
-Found 9 errors in 6 files.
+Found 10 errors in 7 files.
 
 Errors  Files
-     4  ts-check.md[90m:109[0m
+     1  ts-check.md[90m:128[0m
+     4  ts-check.md[90m:154[0m
      1  ts-check.md[90m:4[0m
-     1  ts-check.md[90m:54[0m
-     1  ts-check.md[90m:60[0m
+     1  ts-check.md[90m:66[0m
+     1  ts-check.md[90m:72[0m
      1  ts-check.md[90m:8[0m
-     1  ts-check.md[90m:83[0m
+     1  ts-check.md[90m:95[0m
 
 "
 `;

--- a/tests/fixtures/ts-check.md
+++ b/tests/fixtures/ts-check.md
@@ -18,7 +18,7 @@ console.bar('whoops')
 console.bar('whoops')
 ```
 
-These blocks ignore specific lines (1-based)
+These blocks suppress specific lines (1-based)
 
 ```js @ts-ignore=[3]
 console.log('test')
@@ -27,6 +27,18 @@ window.myAwesomeAPI()
 ```
 
 ```js title='main.js' @ts-ignore=[3]
+console.log('test')
+
+window.myAwesomeAPI()
+```
+
+```js @ts-expect-error=[3]
+console.log('test')
+
+window.myAwesomeAPI()
+```
+
+```js title='main.js' @ts-expect-error=[3]
 console.log('test')
 
 window.myAwesomeAPI()
@@ -87,6 +99,39 @@ window.myOtherAwesomeAPI()
 This confirms @ts-ignore works if the previous line is a comment
 
 ```js @ts-ignore=[4]
+console.log('test')
+
+// This is a comment
+window.myAwesomeAPI()
+```
+
+These blocks have multiple @ts-expect-error lines
+
+```js @ts-expect-error=[3,5]
+console.log('test')
+
+window.myAwesomeAPI()
+
+window.myOtherAwesomeAPI()
+```
+
+```js @ts-expect-error=[1,4]
+window.myAwesomeAPI()
+
+console.log('test')
+window.myOtherAwesomeAPI()
+```
+
+This confirms @ts-expect-error output is stripped
+
+```js @ts-expect-error=[2]
+window.myAwesomeAPI()
+window.myOtherAwesomeAPI()
+```
+
+This confirms @ts-expect-error works if the previous line is a comment
+
+```js @ts-expect-error=[4]
 console.log('test')
 
 // This is a comment


### PR DESCRIPTION
As pointed out by @itsananderson, `@ts-expect-error` is probably a better fit than `@ts-ignore` when type checking of code blocks, since it doesn't have the risk of going stale and ignoring a line incorrectly. In hindsight it would have been better to implement that from the start, but since `@ts-ignore` is already implemented, support both for now, and if `@ts-ignore` support is adding no value, remove it in the future.