### PR TITLE
feat: add --semi option to electron-lint-markdown-standard

### DIFF
--- a/tests/electron-lint-markdown-standard.spec.ts
+++ b/tests/electron-lint-markdown-standard.spec.ts
@@ -47,6 +47,8 @@ describe('electron-lint-markdown-standard', () => {
       '**/cleanable.md',
       '--ignore',
       '**/dirty.md',
+      '--ignore',
+      '**/semi.md',
       '*.md',
     );
 
@@ -106,6 +108,26 @@ describe('electron-lint-markdown-standard', () => {
       expect(status).toEqual(1);
     } finally {
       await fs.rm(tmpdir, { recursive: true, force: true });
+    }
+  });
+
+  it('can enforce semicolons with --semi', () => {
+    {
+      // Error if there are no semicolons and --semi option set
+      const { status } = runLintMarkdownStandard('--root', FIXTURES_DIR, '--semi', 'clean.md');
+      expect(status).toEqual(1);
+    }
+
+    {
+      // Error if there are semicolons and --semi option NOT set
+      const { status } = runLintMarkdownStandard('--root', FIXTURES_DIR, 'semi.md');
+      expect(status).toEqual(1);
+    }
+
+    {
+      // No error if there are semicolons and --semi option set
+      const { status } = runLintMarkdownStandard('--root', FIXTURES_DIR, '--semi', 'semi.md');
+      expect(status).toEqual(0);
     }
   });
 });

--- a/tests/fixtures/semi.md
+++ b/tests/fixtures/semi.md
@@ -1,0 +1,78 @@
+# The Semi Readme
+
+This is a markdown file with some javascript code blocks in it, with semicolons.
+
+```js
+console.log('all good here!');
+```
+
+There are no linting errors in this file.
+
+```javascript
+const wibble = 2;
+console.log(wibble);
+```
+
+It should allow use of undefined variables
+
+```javascript
+win.close();
+```
+
+It should allow creation of unused variables
+
+```js
+// `BrowserWindow` is declared but not used
+const { BrowserWindow } = require('electron');
+```
+
+It should allow orphan objects:
+
+```js
+{ some: 'object' }
+```
+
+and this wrapping kind too:
+
+```js
+{
+  some: 'object',
+  with: 'different whitespace and tabbing'
+}
+```
+
+and arrays:
+
+```js
+[1, 2, 3]
+```
+
+and wrapped arrays:
+
+```js
+[
+  4,
+  5,
+  6
+]
+```
+
+Electron docs have a bunch of non-node-style callbacks that don't have `err` as the first arg:
+
+```javascript
+const { app } = require('electron');
+
+app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
+  if (url === 'https://github.com') {
+    callback(true);
+  } else {
+    callback(false);
+  }
+});
+```
+
+1. Indented code
+
+   ```js
+   console.log('all good here!');
+   ```


### PR DESCRIPTION
In some repos we use semicolons in the example code, like `electron/forge`. Add the `--semi` option to effectively turn it into `standard/semistandard` but simpler than adding that package as a dependency.