### PR TITLE
feat: add ts-window-type for type checking code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ detection of code blocks.
 Markdown with `tsc`. Type checking can be disabled for specific code blocks
 by adding `@ts-nocheck` to the info string, specific lines can be ignored
 by adding `@ts-ignore=[<line1>,<line2>]` to the info string, and additional
-globals can be defined with `@ts-type={name:type}`.
+globals can be defined with `@ts-type={name:type}`. The `Window` object can
+be extended with more types using `@ts-window-type={name:type}`.
 
 ## License
 

--- a/tests/__snapshots__/electron-lint-markdown-ts-check.spec.ts.snap
+++ b/tests/__snapshots__/electron-lint-markdown-ts-check.spec.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`electron-lint-markdown-ts-check should type check code blocks 1`] = `
-"ts-check.md:49:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignore/@ts-type, they conflict
-ts-check.md:55:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignore/@ts-type, they conflict
+"ts-check.md:49:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignore/@ts-type/@ts-window-type, they conflict
+ts-check.md:55:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignore/@ts-type/@ts-window-type, they conflict
 [96mts-check.md[0m:[93m128[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'myAwesomeAPI' does not exist on type 'Window & typeof globalThis'.
 
 [7m128[0m window.myAwesomeAPI()
@@ -27,6 +27,11 @@ ts-check.md:55:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignor
 
 [7m157[0m   console.log(\`not true: \${a} < \${b}\`)
 [7m   [0m [91m                                  ~[0m
+
+[96mts-check.md[0m:[93m160[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'AwesomeAPI' does not exist on type 'Window & typeof globalThis'.
+
+[7m160[0m window.AwesomeAPI.bar('baz')
+[7m   [0m [91m       ~~~~~~~~~~[0m
 
 [96mts-check.md[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2339: [0mProperty 'foo' does not exist on type 'Console'.
 
@@ -54,11 +59,11 @@ ts-check.md:55:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignor
 [7m  [0m [91m       ~~~~~~~~~~~~[0m
 
 
-Found 10 errors in 7 files.
+Found 11 errors in 7 files.
 
 Errors  Files
      1  ts-check.md[90m:128[0m
-     4  ts-check.md[90m:154[0m
+     5  ts-check.md[90m:154[0m
      1  ts-check.md[90m:4[0m
      1  ts-check.md[90m:66[0m
      1  ts-check.md[90m:72[0m

--- a/tests/fixtures/ts-check.md
+++ b/tests/fixtures/ts-check.md
@@ -156,4 +156,12 @@ if (a > b) {
 } else {
   console.log(`not true: ${a} < ${b}`)
 }
+
+window.AwesomeAPI.bar('baz')
+```
+
+This block defines additional types on window
+
+```js @ts-window-type={AwesomeAPI: { foo: (value: number) => void } }
+window.AwesomeAPI.foo(42)
 ```


### PR DESCRIPTION
Needs #22 to land first.

Adds a `@ts-window-type={name:type}` directive for adding types to the global `Window` object, which some code examples in the Electron docs need for type checking.