### PR TITLE
feat: type check TypeScript code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,15 @@ check external links with the `--fetch-external-links` option.
 Markdown with `standard`, like `standard-markdown` does, but with better
 detection of code blocks.
 
-`electron-lint-markdown-ts-check` is a command to type check JS code blocks in
-Markdown with `tsc`. Type checking can be disabled for specific code blocks
+`electron-lint-markdown-ts-check` is a command to type check JS/TS code blocks
+in Markdown with `tsc`. Type checking can be disabled for specific code blocks
 by adding `@ts-nocheck` to the info string, specific lines can be ignored
 by adding `@ts-ignore=[<line1>,<line2>]` to the info string, and additional
 globals can be defined with `@ts-type={name:type}`. The `Window` object can
-be extended with more types using `@ts-window-type={name:type}`.
+be extended with more types using `@ts-window-type={name:type}`. When type
+checking TypeScript blocks in the same Markdown file, global augmentation
+(via `declare global`) can be shared between code blocks by putting
+`@ts-noisolate` on the code block doing the global augmentation.
 
 ## License
 

--- a/tests/__snapshots__/electron-lint-markdown-ts-check.spec.ts.snap
+++ b/tests/__snapshots__/electron-lint-markdown-ts-check.spec.ts.snap
@@ -33,6 +33,21 @@ ts-check.md:55:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignor
 [7m160[0m window.AwesomeAPI.bar('baz')
 [7m   [0m [91m       ~~~~~~~~~~[0m
 
+[96mts-check.md[0m:[93m174[0m:[93m15[0m - [91merror[0m[90m TS2339: [0mProperty 'wrongAPI' does not exist on type 'typeof BrowserWindow'.
+
+[7m174[0m BrowserWindow.wrongAPI('foo')
+[7m   [0m [91m              ~~~~~~~~[0m
+
+[96mts-check.md[0m:[93m180[0m:[93m15[0m - [91merror[0m[90m TS2339: [0mProperty 'wrongAPI' does not exist on type 'typeof BrowserWindow'.
+
+[7m180[0m BrowserWindow.wrongAPI('foo')
+[7m   [0m [91m              ~~~~~~~~[0m
+
+[96mts-check.md[0m:[93m212[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'AwesomeAPI' does not exist on type 'Window & typeof globalThis'.
+
+[7m212[0m window.AwesomeAPI.foo(42)
+[7m   [0m [91m       ~~~~~~~~~~[0m
+
 [96mts-check.md[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2339: [0mProperty 'foo' does not exist on type 'Console'.
 
 [7m4[0m console.foo('whoops')
@@ -59,11 +74,14 @@ ts-check.md:55:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignor
 [7m  [0m [91m       ~~~~~~~~~~~~[0m
 
 
-Found 11 errors in 7 files.
+Found 14 errors in 10 files.
 
 Errors  Files
      1  ts-check.md[90m:128[0m
      5  ts-check.md[90m:154[0m
+     1  ts-check.md[90m:174[0m
+     1  ts-check.md[90m:180[0m
+     1  ts-check.md[90m:212[0m
      1  ts-check.md[90m:4[0m
      1  ts-check.md[90m:66[0m
      1  ts-check.md[90m:72[0m

--- a/tests/fixtures/ts-check-clean.md
+++ b/tests/fixtures/ts-check-clean.md
@@ -7,3 +7,11 @@ console.log('Hello world!')
 ```js title='main.js'
 console.log('Hello world!')
 ```
+
+```typescript
+console.log('Hello world!')
+```
+
+```typescript title='main.js'
+console.log('Hello world!')
+```

--- a/tests/fixtures/ts-check.md
+++ b/tests/fixtures/ts-check.md
@@ -165,3 +165,50 @@ This block defines additional types on window
 ```js @ts-window-type={AwesomeAPI: { foo: (value: number) => void } }
 window.AwesomeAPI.foo(42)
 ```
+
+These TypeScript blocks have bad usage of Electron APIs
+
+```ts
+const { BrowserWindow } = require('electron')
+
+BrowserWindow.wrongAPI('foo')
+```
+
+```TypeScript
+import { BrowserWindow } from 'electron'
+
+BrowserWindow.wrongAPI('foo')
+```
+
+The first block should be isolated from the third block but the second should not
+
+```typescript
+interface IAwesomeAPI {
+  foo: (number) => void;
+}
+
+declare global {
+  interface Window {
+    AwesomeAPI: IAwesomeAPI;
+  }
+}
+
+window.AwesomeAPI.foo(42)
+```
+
+```typescript @ts-noisolate
+interface IOtherAwesomeAPI {
+  bar: (string) => void;
+}
+
+declare global {
+  interface Window {
+    OtherAwesomeAPI: IOtherAwesomeAPI;
+  }
+}
+```
+
+```ts
+window.AwesomeAPI.foo(42)
+window.OtherAwesomeAPI.bar('baz')
+```


### PR DESCRIPTION
~~Needs #23 to land first, which in turn needs #22 to land first.~~

Supports type checking TS code blocks, which perhaps ironically were not type checked before this change. Also introduces a `@ts-noisolate` directive to allow global augmentation in one code block to bleed into others, which can be useful to avoid reiterating types when a subsequent block uses ones defined earlier.