### PR TITLE
ci: use electronjs/node orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,105 +2,31 @@ version: 2.1
 
 orbs:
   cfa: continuousauth/npm@1.0.2
-  node: circleci/node@5.1.0
-  win: circleci/windows@5.0.0
-
-commands:
-  install:
-    parameters:
-      node-version:
-        description: Node.js version to install
-        type: string
-    steps:
-      - run: git config --global core.autocrlf input
-      - node/install:
-          node-version: << parameters.node-version >>
-      - run: nvm use << parameters.node-version >>
-      # Can't get yarn installed on Windows with the circleci/node orb, so use npx yarn for commands
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
-            - v1-dependencies-{{ arch }}
-      - run: npx yarn install --frozen-lockfile
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
-
-jobs:
-  test-linux:
-    docker:
-      - image: cimg/base:stable
-    parameters:
-      node-version:
-        description: Node.js version to install
-        type: string
-    steps:
-      - install:
-          node-version: << parameters.node-version >>
-      - run: npx yarn test
-  test-mac:
-    macos:
-      xcode: "14.0.0"
-    resource_class: macos.x86.medium.gen2
-    parameters:
-      node-version:
-        description: Node.js version to install
-        type: string
-    steps:
-      - install:
-          node-version: << parameters.node-version >>
-      - run: npx yarn test
-  test-windows:
-    executor:
-      name: win/default
-      shell: bash.exe
-    parameters:
-      node-version:
-        description: Node.js version to install
-        type: string
-    steps:
-      - install:
-          node-version: << parameters.node-version >>
-      - run: npx yarn test
+  node: electronjs/node@1.1.0
 
 workflows:
   test_and_release:
     # Run the test jobs first, then the release only when all the test jobs are successful
     jobs:
-      - test-linux:
+      - node/test:
+          name: test-<< matrix.executor >>-<< matrix.node-version >>
+          pre-steps:
+            - run: git config --global core.autocrlf input
           matrix:
+            alias: test
             parameters:
+              executor:
+                - node/linux
+                - node/macos
+                - node/windows
               node-version:
-                - 18.14.0
-                - 16.19.0
-                - 14.19.0
-      - test-mac:
-          matrix:
-            parameters:
-              node-version:
-                - 18.14.0
-                - 16.19.0
-                - 14.19.0
-      - test-windows:
-          matrix:
-            parameters:
-              node-version:
-                - 18.14.0
-                - 16.19.0
-                - 14.19.0
+                - 20.2.0
+                - 18.17.0
+                - 16.20.1
+                - 14.21.3
       - cfa/release:
           requires:
-            - test-linux-18.14.0
-            - test-linux-16.19.0
-            - test-linux-14.19.0
-            - test-mac-18.14.0
-            - test-mac-16.19.0
-            - test-mac-14.19.0
-            - test-windows-18.14.0
-            - test-windows-16.19.0
-            - test-windows-14.19.0
+            - test
           filters:
             branches:
               only:


### PR DESCRIPTION
Use `electronjs/node` orb to pick up caching of Node.js installs, and significantly simplify this CircleCI config.