### PR TITLE
feat: make getCodeBlocks more reusable

### DIFF
--- a/bin/lint-markdown-standard.ts
+++ b/bin/lint-markdown-standard.ts
@@ -62,7 +62,7 @@ async function main(
     const filepath = workspace.getWorkspaceRelativePath(uri);
     const changes: TextEdit[] = [];
 
-    const jsCodeBlocks = (await getCodeBlocks(document)).filter(
+    const jsCodeBlocks = (await getCodeBlocks(document.getText())).filter(
       (code) => code.lang && ['javascript', 'js'].includes(code.lang.toLowerCase()),
     );
 

--- a/bin/lint-markdown-ts-check.ts
+++ b/bin/lint-markdown-ts-check.ts
@@ -126,7 +126,7 @@ async function main(workspaceRoot: string, globs: string[], { ignoreGlobs = [] }
     for (const document of await workspace.getAllMarkdownDocuments()) {
       const uri = URI.parse(document.uri);
       const filepath = workspace.getWorkspaceRelativePath(uri);
-      const codeBlocks = (await getCodeBlocks(document)).filter(
+      const codeBlocks = (await getCodeBlocks(document.getText())).filter(
         (code) =>
           code.lang && ['javascript', 'js', 'typescript', 'ts'].includes(code.lang.toLowerCase()),
       );

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -335,7 +335,7 @@ export class MarkdownLinkComputer implements IMdLinkComputer {
   }
 }
 
-export async function getCodeBlocks(document: ITextDocument): Promise<Code[]> {
+export async function getCodeBlocks(content: string): Promise<Code[]> {
   const { fromMarkdown } = (await dynamicImport('mdast-util-from-markdown')) as {
     fromMarkdown: typeof FromMarkdownFunction;
   };
@@ -343,7 +343,7 @@ export async function getCodeBlocks(document: ITextDocument): Promise<Code[]> {
     visit: typeof VisitFunction;
   };
 
-  const tree = fromMarkdown(document.getText());
+  const tree = fromMarkdown(content);
 
   const codeBlocks: Code[] = [];
 


### PR DESCRIPTION
Make this a bit more easily reused for usage in linting scripts in `e/e`. Marking it as 'feat' so it triggers a new release. While technically a breaking change, the internal helpers are exposed for convenience and no guarantee is made regarding their API stability.