### PR TITLE
fix: don't flag GitHub alert syntax in the no shortcut link rule

### DIFF
--- a/markdownlint-rules/emd001.js
+++ b/markdownlint-rules/emd001.js
@@ -1,5 +1,9 @@
 const { addError, getLineMetadata, getReferenceLinkImageData } = require('markdownlint/helpers');
 
+// These are used by GitHub's "alert" extension to Markdown
+// https://github.com/orgs/community/discussions/16925
+const ALERT_KEYWORDS = ['!note', '!tip', '!important', '!warning', '!caution'];
+
 module.exports = {
   names: ['EMD001', 'no-shortcut-reference-links'],
   description: 'Disallow shortcut reference links (those with no link label)',
@@ -9,11 +13,13 @@ module.exports = {
     const { shortcuts } = getReferenceLinkImageData(lineMetadata);
     for (const [shortcut, occurrences] of shortcuts) {
       for (const [lineNumber] of occurrences) {
-        addError(
-          onError,
-          lineNumber + 1, // human-friendly line numbers (1-based)
-          `Disallowed shortcut reference link: "${shortcut}"`,
-        );
+        if (!ALERT_KEYWORDS.includes(shortcut)) {
+          addError(
+            onError,
+            lineNumber + 1, // human-friendly line numbers (1-based)
+            `Disallowed shortcut reference link: "${shortcut}"`,
+          );
+        }
       }
     }
   },

--- a/tests/electron-markdownlint.spec.ts
+++ b/tests/electron-markdownlint.spec.ts
@@ -17,4 +17,17 @@ describe('electron-markdownlint', () => {
     expect(stderr.toString('utf-8')).toContain('EMD001/no-shortcut-reference-links');
     expect(status).toEqual(1);
   });
+
+  it('should allow GitHub alert syntax', () => {
+    const { status } = cp.spawnSync(
+      process.execPath,
+      [
+        path.resolve(__dirname, '../dist/bin/markdownlint-cli-wrapper.js'),
+        path.resolve(FIXTURES_DIR, 'github-alerts.md'),
+      ],
+      { stdio: 'pipe' },
+    );
+
+    expect(status).toEqual(0);
+  });
 });

--- a/tests/fixtures/github-alerts.md
+++ b/tests/fixtures/github-alerts.md
@@ -1,0 +1,16 @@
+<!-- Taken from https://github.com/orgs/community/discussions/16925 -->
+
+> [!NOTE]
+> Highlights information that users should take into account, even when skimming.
+
+> [!TIP]
+> Optional information to help a user be more successful.
+
+> [!IMPORTANT]
+> Crucial information necessary for users to succeed.
+
+> [!WARNING]
+> Critical content demanding immediate user attention due to potential risks.
+
+> [!CAUTION]
+> Negative potential consequences of an action.


### PR DESCRIPTION
We want to allow these.