### PR TITLE
chore: fix version of typescript peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
     "vscode-uri": "^3.0.7"
   },
   "peerDependencies": {
-    "typescript": "^4.5.5"
+    "typescript": ">= 4.7.0"
   }
 }


### PR DESCRIPTION
This was both overly restrictive (TypeScript 5 works fine) and too low (min is 4.7), so correcting it. Needs at least TypeScript 4.7 due to the usage of the `--moduleDetection` flag.

https://github.com/electron/lint-roller/blob/0b3adf9f514f57b3efd5eb56045e0f7c7120956a/bin/lint-markdown-ts-check.ts#L59