### PR TITLE
fix: mark typescript as optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,10 @@
   },
   "peerDependencies": {
     "typescript": ">= 4.7.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
The `typescript` package is only needed for `electron-lint-markdown-ts-check`, so mark it as an optional peer dependency.