### PR TITLE
feat: use Node.js global fetch if available

### DIFF
--- a/bin/lint-markdown-links.ts
+++ b/bin/lint-markdown-links.ts
@@ -11,7 +11,6 @@ import {
   LogLevel,
 } from '@dsanders11/vscode-markdown-languageservice';
 import * as minimist from 'minimist';
-import fetch from 'node-fetch';
 import { CancellationTokenSource } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 
@@ -34,6 +33,12 @@ const diagnosticOptions: DiagnosticOptions = {
 };
 
 async function fetchExternalLink(link: string, checkRedirects = false) {
+  // Use global fetch if available, otherwise fall back to node-fetch
+  if (!('fetch' in global)) {
+    const { default: fetch } = await import('node-fetch');
+    (global as any).fetch = fetch;
+  }
+
   try {
     const response = await fetch(link);
     if (response.status !== 200) {

--- a/tests/electron-lint-markdown-links.spec.ts
+++ b/tests/electron-lint-markdown-links.spec.ts
@@ -11,6 +11,8 @@ function runLintMarkdownLinks(...args: string[]) {
   );
 }
 
+const nodeVersion = parseInt(process.version.match(/^v(\d+)\./)![1]);
+
 describe('electron-lint-markdown-links', () => {
   it('should catch broken internal links', () => {
     const { status, stdout } = runLintMarkdownLinks(
@@ -125,4 +127,17 @@ describe('electron-lint-markdown-links', () => {
     expect(stdout.toString('utf-8')).toContain('Broken link');
     expect(status).toEqual(1);
   });
+
+  if (nodeVersion >= 18) {
+    it('should be able to fetch GitHub label URLs', () => {
+      const { status } = runLintMarkdownLinks(
+        '--root',
+        FIXTURES_DIR,
+        'github-label-link.md',
+        '--fetch-external-links',
+      );
+
+      expect(status).toEqual(0);
+    });
+  }
 });

--- a/tests/fixtures/github-label-link.md
+++ b/tests/fixtures/github-label-link.md
@@ -1,0 +1,1 @@
+This is an [external link](https://github.com/electron/fiddle/labels/ESM)


### PR DESCRIPTION
Some time last week something changed with GitHub's servers that causes `node-fetch` to get a 404 when fetching certain links (notably labels on a repo). Works fine with the global fetch in Node.js, so use that if available to work around the issue.

`node-fetch` will be dropped in a future breaking change anyway.