### PR TITLE
fix: set user agent to allow fetching Twitter links

### DIFF
--- a/bin/lint-markdown-links.ts
+++ b/bin/lint-markdown-links.ts
@@ -40,7 +40,12 @@ async function fetchExternalLink(link: string, checkRedirects = false) {
   }
 
   try {
-    const response = await fetch(link);
+    const response = await fetch(link, {
+      headers: {
+        'user-agent':
+          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)  Chrome/122.0.6261.39 Electron/29.0.0 Safari/537.36',
+      },
+    });
     if (response.status !== 200) {
       console.log('Broken link', link, response.status, response.statusText);
     } else {

--- a/tests/electron-lint-markdown-links.spec.ts
+++ b/tests/electron-lint-markdown-links.spec.ts
@@ -140,4 +140,15 @@ describe('electron-lint-markdown-links', () => {
       expect(status).toEqual(0);
     });
   }
+
+  it('should be able to fetch twitter links', () => {
+    const { status } = runLintMarkdownLinks(
+      '--root',
+      FIXTURES_DIR,
+      'twitter-link.md',
+      '--fetch-external-links',
+    );
+
+    expect(status).toEqual(0);
+  });
 });

--- a/tests/fixtures/twitter-link.md
+++ b/tests/fixtures/twitter-link.md
@@ -1,0 +1,1 @@
+This is an [twitter link](https://twitter.com/electronjs)


### PR DESCRIPTION
Fetching Twitter links was failing, but can be fixed by setting the user agent. This may also improve issues seen with fetching GitHub label links.