### PR TITLE
feat!: rename ts-check binary and add config support [skip release]

### DIFF
--- a/.lint-roller.schema.json
+++ b/.lint-roller.schema.json
@@ -1,0 +1,34 @@
+{
+  "title": "JSON schema for @electron/lint-roller config files",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "markdown-ts-check": {
+      "description": "Configuration for the lint-roller-markdown-ts-check script",
+      "type": "object",
+      "properties": {
+        "defaultImports": {
+          "description": "Default imports to include when type checking a TypeScript code block",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "typings": {
+          "description": ".d.ts files (paths relative to root) to include when type checking a code block",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Markdown with `standard`, like `standard-markdown` does, but with better
 detection of code blocks. Linting can be disabled for specific code blocks
 by adding `@nolint` to the info string.
 
-`electron-lint-markdown-ts-check` is a command to type check JS/TS code blocks
+`lint-roller-markdown-ts-check` is a command to type check JS/TS code blocks
 in Markdown with `tsc`. Type checking can be disabled for specific code blocks
 by adding `@ts-nocheck` to the info string, specific lines can be ignored
 by adding `@ts-ignore=[<line1>,<line2>]` to the info string, and additional

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -112,5 +112,9 @@ export function loadConfig(path: string) {
 
   const config = fs.readFileSync(path, 'utf8');
 
-  return JSON.parse(config) as LintRollerConfig;
+  try {
+    return JSON.parse(config) as LintRollerConfig;
+  } catch {
+    throw new Error(`Couldn't parse config at ${path}`);
+  }
 }

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,4 +1,5 @@
 import * as childProcess from 'node:child_process';
+import * as fs from 'node:fs';
 import * as os from 'node:os';
 
 import { range as balancedRange } from 'balanced-match';
@@ -93,4 +94,23 @@ export function findCurlyBracedDirectives(directive: string, str: string) {
   }
 
   return matches;
+}
+
+export interface LintRollerTsCheckConfig {
+  defaultImports?: string[];
+  typings?: string[];
+}
+
+export interface LintRollerConfig {
+  'markdown-ts-check'?: LintRollerTsCheckConfig;
+}
+
+export function loadConfig(path: string) {
+  if (!fs.existsSync(path)) {
+    return undefined;
+  }
+
+  const config = fs.readFileSync(path, 'utf8');
+
+  return JSON.parse(config) as LintRollerConfig;
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "electron-markdownlint": "./dist/bin/markdownlint-cli-wrapper.js",
     "electron-lint-markdown-links": "./dist/bin/lint-markdown-links.js",
     "electron-lint-markdown-standard": "./dist/bin/lint-markdown-standard.js",
-    "electron-lint-markdown-ts-check": "./dist/bin/lint-markdown-ts-check.js"
+    "lint-roller-markdown-ts-check": "./dist/bin/lint-markdown-ts-check.js"
   },
   "files": [
     "configs",

--- a/tests/__snapshots__/lint-roller-markdown-ts-check.spec.ts.snap
+++ b/tests/__snapshots__/lint-roller-markdown-ts-check.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`electron-lint-markdown-ts-check should type check code blocks 1`] = `
+exports[`lint-roller-markdown-ts-check should type check code blocks 1`] = `
 "ts-check.md:49:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignore/@ts-type/@ts-window-type, they conflict
 ts-check.md:55:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignore/@ts-type/@ts-window-type, they conflict
 [96mts-check.md[0m:[93m128[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'myAwesomeAPI' does not exist on type 'Window & typeof globalThis'.

--- a/tests/fixtures/.lint-roller.json
+++ b/tests/fixtures/.lint-roller.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../.lint-roller.schema.json",
+  "markdown-ts-check": {
+    "defaultImports": [
+      "import * as childProcess from 'node:child_process'",
+      "import * as fs from 'node:fs'",
+      "import * as path from 'node:path'",
+      "import { app, BrowserWindow } from 'electron'"
+    ],
+    "typings": [
+      "./electron.d.ts"
+    ]
+  }
+}

--- a/tests/fixtures/custom-config.json
+++ b/tests/fixtures/custom-config.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../.lint-roller.schema.json",
+  "markdown-ts-check": {
+    "defaultImports": [
+      "import { performance } from 'node:perf_hooks'"
+    ]
+  }
+}

--- a/tests/fixtures/ts-check-custom-config.md
+++ b/tests/fixtures/ts-check-custom-config.md
@@ -1,0 +1,15 @@
+```js
+performance.measure('Start to Now')
+```
+
+```js @ts-expect-error=[1]
+performance.Xmeasure('Start to Now')
+```
+
+```ts
+performance.measure('Start to Now')
+```
+
+```ts @ts-expect-error=[1]
+performance.Xmeasure('Start to Now')
+```

--- a/tests/fixtures/ts-check.md
+++ b/tests/fixtures/ts-check.md
@@ -212,3 +212,11 @@ declare global {
 window.AwesomeAPI.foo(42)
 window.OtherAwesomeAPI.bar('baz')
 ```
+
+```js @ts-expect-error=[1]
+fs.wrongApi('hello')
+```
+
+```ts @ts-expect-error=[1]
+fs.wrongApi('hello')
+```

--- a/tests/lint-roller-markdown-ts-check.spec.ts
+++ b/tests/lint-roller-markdown-ts-check.spec.ts
@@ -11,7 +11,7 @@ function runLintMarkdownTsCheck(...args: string[]) {
   );
 }
 
-describe('electron-lint-markdown-ts-check', () => {
+describe('lint-roller-markdown-ts-check', () => {
   it('should run clean when there are no errors', () => {
     const { status, stdout } = runLintMarkdownTsCheck('--root', FIXTURES_DIR, 'ts-check-clean.md');
 
@@ -62,5 +62,19 @@ describe('electron-lint-markdown-ts-check', () => {
 
     expect(stdout.replace(FIXTURES_DIR, '<root>')).toMatchSnapshot();
     expect(status).toEqual(1);
+  });
+
+  it('can use a custom config', () => {
+    const { status, stdout, stderr } = runLintMarkdownTsCheck(
+      '--root',
+      FIXTURES_DIR,
+      '--config',
+      'custom-config.json',
+      'ts-check-custom-config.md',
+    );
+
+    expect(stdout).toEqual('');
+    expect(stderr).toEqual('');
+    expect(status).toEqual(0);
   });
 });


### PR DESCRIPTION
This removes all Electron-specific bits from the `markdown-ts-check` binary so that it is generic and can be used for any project.

Marking to skip release as this is part of multiple breaking changes I want to ship as a single v2, so the final PR will trigger the major release.