### PR TITLE
chore!: remove @ts-ignore syntax [skip release]

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ by adding `@nolint` to the info string.
 
 `lint-roller-markdown-ts-check` is a command to type check JS/TS code blocks
 in Markdown with `tsc`. Type checking can be disabled for specific code blocks
-by adding `@ts-nocheck` to the info string, specific lines can be ignored
-by adding `@ts-ignore=[<line1>,<line2>]` to the info string, and additional
+by adding `@ts-nocheck` to the info string, specific lines can be ignored by
+adding `@ts-expect-error=[<line1>,<line2>]` to the info string, and additional
 globals can be defined with `@ts-type={name:type}`. The `Window` object can
 be extended with more types using `@ts-window-type={name:type}`. When type
 checking TypeScript blocks in the same Markdown file, global augmentation

--- a/tests/__snapshots__/lint-roller-markdown-ts-check.spec.ts.snap
+++ b/tests/__snapshots__/lint-roller-markdown-ts-check.spec.ts.snap
@@ -1,51 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`lint-roller-markdown-ts-check should type check code blocks 1`] = `
-"ts-check.md:49:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignore/@ts-type/@ts-window-type, they conflict
-ts-check.md:55:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignore/@ts-type/@ts-window-type, they conflict
-[96mts-check.md[0m:[93m128[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'myAwesomeAPI' does not exist on type 'Window & typeof globalThis'.
+"ts-check.md:37:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-type/@ts-window-type, they conflict
+ts-check.md:43:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-type/@ts-window-type, they conflict
+[96mts-check.md[0m:[93m109[0m:[93m5[0m - [91merror[0m[90m TS2304: [0mCannot find name 'a'.
 
-[7m128[0m window.myAwesomeAPI()
-[7m   [0m [91m       ~~~~~~~~~~~~[0m
-
-[96mts-check.md[0m:[93m154[0m:[93m5[0m - [91merror[0m[90m TS2304: [0mCannot find name 'a'.
-
-[7m154[0m if (a > b) {
+[7m109[0m if (a > b) {
 [7m   [0m [91m    ~[0m
 
-[96mts-check.md[0m:[93m154[0m:[93m9[0m - [91merror[0m[90m TS2304: [0mCannot find name 'b'.
+[96mts-check.md[0m:[93m109[0m:[93m9[0m - [91merror[0m[90m TS2304: [0mCannot find name 'b'.
 
-[7m154[0m if (a > b) {
+[7m109[0m if (a > b) {
 [7m   [0m [91m        ~[0m
 
-[96mts-check.md[0m:[93m157[0m:[93m28[0m - [91merror[0m[90m TS2304: [0mCannot find name 'a'.
+[96mts-check.md[0m:[93m112[0m:[93m28[0m - [91merror[0m[90m TS2304: [0mCannot find name 'a'.
 
-[7m157[0m   console.log(\`not true: \${a} < \${b}\`)
+[7m112[0m   console.log(\`not true: \${a} < \${b}\`)
 [7m   [0m [91m                           ~[0m
 
-[96mts-check.md[0m:[93m157[0m:[93m35[0m - [91merror[0m[90m TS2304: [0mCannot find name 'b'.
+[96mts-check.md[0m:[93m112[0m:[93m35[0m - [91merror[0m[90m TS2304: [0mCannot find name 'b'.
 
-[7m157[0m   console.log(\`not true: \${a} < \${b}\`)
+[7m112[0m   console.log(\`not true: \${a} < \${b}\`)
 [7m   [0m [91m                                  ~[0m
 
-[96mts-check.md[0m:[93m160[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'AwesomeAPI' does not exist on type 'Window & typeof globalThis'.
+[96mts-check.md[0m:[93m115[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'AwesomeAPI' does not exist on type 'Window & typeof globalThis'.
 
-[7m160[0m window.AwesomeAPI.bar('baz')
+[7m115[0m window.AwesomeAPI.bar('baz')
 [7m   [0m [91m       ~~~~~~~~~~[0m
 
-[96mts-check.md[0m:[93m174[0m:[93m15[0m - [91merror[0m[90m TS2339: [0mProperty 'wrongAPI' does not exist on type 'typeof BrowserWindow'.
+[96mts-check.md[0m:[93m129[0m:[93m15[0m - [91merror[0m[90m TS2339: [0mProperty 'wrongAPI' does not exist on type 'typeof BrowserWindow'.
 
-[7m174[0m BrowserWindow.wrongAPI('foo')
+[7m129[0m BrowserWindow.wrongAPI('foo')
 [7m   [0m [91m              ~~~~~~~~[0m
 
-[96mts-check.md[0m:[93m180[0m:[93m15[0m - [91merror[0m[90m TS2339: [0mProperty 'wrongAPI' does not exist on type 'typeof BrowserWindow'.
+[96mts-check.md[0m:[93m135[0m:[93m15[0m - [91merror[0m[90m TS2339: [0mProperty 'wrongAPI' does not exist on type 'typeof BrowserWindow'.
 
-[7m180[0m BrowserWindow.wrongAPI('foo')
+[7m135[0m BrowserWindow.wrongAPI('foo')
 [7m   [0m [91m              ~~~~~~~~[0m
 
-[96mts-check.md[0m:[93m212[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'AwesomeAPI' does not exist on type 'Window & typeof globalThis'.
+[96mts-check.md[0m:[93m167[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'AwesomeAPI' does not exist on type 'Window & typeof globalThis'.
 
-[7m212[0m window.AwesomeAPI.foo(42)
+[7m167[0m window.AwesomeAPI.foo(42)
 [7m   [0m [91m       ~~~~~~~~~~[0m
 
 [96mts-check.md[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2339: [0mProperty 'foo' does not exist on type 'Console'.
@@ -53,14 +48,14 @@ ts-check.md:55:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignor
 [7m4[0m console.foo('whoops')
 [7m [0m [91m        ~~~[0m
 
-[96mts-check.md[0m:[93m66[0m:[93m15[0m - [91merror[0m[90m TS2339: [0mProperty 'wrongAPI' does not exist on type 'typeof BrowserWindow'.
+[96mts-check.md[0m:[93m54[0m:[93m15[0m - [91merror[0m[90m TS2339: [0mProperty 'wrongAPI' does not exist on type 'typeof BrowserWindow'.
 
-[7m66[0m BrowserWindow.wrongAPI('foo')
+[7m54[0m BrowserWindow.wrongAPI('foo')
 [7m  [0m [91m              ~~~~~~~~[0m
 
-[96mts-check.md[0m:[93m72[0m:[93m15[0m - [91merror[0m[90m TS2339: [0mProperty 'wrongAPI' does not exist on type 'typeof BrowserWindow'.
+[96mts-check.md[0m:[93m60[0m:[93m15[0m - [91merror[0m[90m TS2339: [0mProperty 'wrongAPI' does not exist on type 'typeof BrowserWindow'.
 
-[7m72[0m BrowserWindow.wrongAPI('foo')
+[7m60[0m BrowserWindow.wrongAPI('foo')
 [7m  [0m [91m              ~~~~~~~~[0m
 
 [96mts-check.md[0m:[93m8[0m:[93m9[0m - [91merror[0m[90m TS2339: [0mProperty 'foo' does not exist on type 'Console'.
@@ -68,25 +63,24 @@ ts-check.md:55:1: Code block has both @ts-nocheck and @ts-expect-error/@ts-ignor
 [7m8[0m console.foo('whoops')
 [7m [0m [91m        ~~~[0m
 
-[96mts-check.md[0m:[93m95[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'myAwesomeAPI' does not exist on type 'Window & typeof globalThis'.
+[96mts-check.md[0m:[93m83[0m:[93m8[0m - [91merror[0m[90m TS2339: [0mProperty 'myAwesomeAPI' does not exist on type 'Window & typeof globalThis'.
 
-[7m95[0m window.myAwesomeAPI()
+[7m83[0m window.myAwesomeAPI()
 [7m  [0m [91m       ~~~~~~~~~~~~[0m
 
 
-Found 14 errors in 10 files.
+Found 13 errors in 9 files.
 
 Errors  Files
-     1  ts-check.md[90m:128[0m
-     5  ts-check.md[90m:154[0m
-     1  ts-check.md[90m:174[0m
-     1  ts-check.md[90m:180[0m
-     1  ts-check.md[90m:212[0m
+     5  ts-check.md[90m:109[0m
+     1  ts-check.md[90m:129[0m
+     1  ts-check.md[90m:135[0m
+     1  ts-check.md[90m:167[0m
      1  ts-check.md[90m:4[0m
-     1  ts-check.md[90m:66[0m
-     1  ts-check.md[90m:72[0m
+     1  ts-check.md[90m:54[0m
+     1  ts-check.md[90m:60[0m
      1  ts-check.md[90m:8[0m
-     1  ts-check.md[90m:95[0m
+     1  ts-check.md[90m:83[0m
 
 "
 `;

--- a/tests/fixtures/ts-check.md
+++ b/tests/fixtures/ts-check.md
@@ -20,18 +20,6 @@ console.bar('whoops')
 
 These blocks suppress specific lines (1-based)
 
-```js @ts-ignore=[3]
-console.log('test')
-
-window.myAwesomeAPI()
-```
-
-```js title='main.js' @ts-ignore=[3]
-console.log('test')
-
-window.myAwesomeAPI()
-```
-
 ```js @ts-expect-error=[3]
 console.log('test')
 
@@ -46,13 +34,13 @@ window.myAwesomeAPI()
 
 These blocks have conflicting options
 
-```js @ts-nocheck @ts-ignore=[3]
+```js @ts-nocheck @ts-expect-error=[3]
 console.log('test')
 
 window.myAwesomeAPI()
 ```
 
-```js @ts-nocheck title='main.js' @ts-ignore=[3]
+```js @ts-nocheck title='main.js' @ts-expect-error=[3]
 console.log('test')
 
 window.myAwesomeAPI()
@@ -70,39 +58,6 @@ BrowserWindow.wrongAPI('foo')
 const { BrowserWindow } = require('electron')
 
 BrowserWindow.wrongAPI('foo')
-```
-
-These blocks have multiple @ts-ignore lines
-
-```js @ts-ignore=[3,5]
-console.log('test')
-
-window.myAwesomeAPI()
-
-window.myOtherAwesomeAPI()
-```
-
-```js @ts-ignore=[1,4]
-window.myAwesomeAPI()
-
-console.log('test')
-window.myOtherAwesomeAPI()
-```
-
-This confirms @ts-ignore output is stripped
-
-```js @ts-ignore=[2]
-window.myAwesomeAPI()
-window.myOtherAwesomeAPI()
-```
-
-This confirms @ts-ignore works if the previous line is a comment
-
-```js @ts-ignore=[4]
-console.log('test')
-
-// This is a comment
-window.myAwesomeAPI()
 ```
 
 These blocks have multiple @ts-expect-error lines

--- a/tests/lint-roller-markdown-ts-check.spec.ts
+++ b/tests/lint-roller-markdown-ts-check.spec.ts
@@ -7,7 +7,12 @@ function runLintMarkdownTsCheck(...args: string[]) {
   return cp.spawnSync(
     process.execPath,
     [path.resolve(__dirname, '../dist/bin/lint-markdown-ts-check.js'), ...args],
-    { stdio: 'pipe', encoding: 'utf-8', cwd: FIXTURES_DIR },
+    {
+      stdio: 'pipe',
+      encoding: 'utf-8',
+      cwd: FIXTURES_DIR,
+      env: { NODE_OPTIONS: '--no-deprecation' },
+    },
   );
 }
 


### PR DESCRIPTION
Chained on top of #56.

`@ts-expect-error` is a much better solution, so remove `@ts-ignore` as it's not providing any value.