### PR TITLE
chore!: rename binaries to be more generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 yarn global add @electron/lint-roller
 
 electron-markdownlint "**/*.md"
-electron-lint-markdown-links --root docs/ "docs/**/*.md"
+lint-roller-markdown-links --root docs/ "docs/**/*.md"
 ```
 
 ## What It Provides
@@ -28,11 +28,11 @@ across repos. To use the base config, extend it in `.markdownlint.json`:
 `electron-markdownlint` is provided as a wrapper command which adds extra
 rules found in this package automatically.
 
-`electron-lint-markdown-links` is a command to further lint links to find
+`lint-roller-markdown-links` is a command to further lint links to find
 broken relative links, including URL fragments, and can also be used to
 check external links with the `--fetch-external-links` option.
 
-`electron-lint-markdown-standard` is a command to lint JS code blocks in
+`lint-roller-markdown-standard` is a command to lint JS code blocks in
 Markdown with `standard`, like `standard-markdown` does, but with better
 detection of code blocks. Linting can be disabled for specific code blocks
 by adding `@nolint` to the info string.

--- a/bin/lint-markdown-links.ts
+++ b/bin/lint-markdown-links.ts
@@ -147,7 +147,7 @@ function parseCommandLine() {
   const showUsage = (arg?: string): boolean => {
     if (!arg || arg.startsWith('-')) {
       console.log(
-        'Usage: electron-lint-markdown-links [--root <dir>] <globs> [-h|--help] [--fetch-external-links] ' +
+        'Usage: lint-roller-markdown-links [--root <dir>] <globs> [-h|--help] [--fetch-external-links] ' +
           '[--check-redirects] [--ignore <globs>]',
       );
       process.exit(1);

--- a/bin/lint-markdown-standard.ts
+++ b/bin/lint-markdown-standard.ts
@@ -170,7 +170,7 @@ function parseCommandLine() {
   const showUsage = (arg?: string): boolean => {
     if (!arg || arg.startsWith('-')) {
       console.log(
-        'Usage: electron-lint-markdown-standard [--root <dir>] <globs> [-h|--help] [--fix]' +
+        'Usage: lint-roller-markdown-standard [--root <dir>] <globs> [-h|--help] [--fix]' +
           '[--ignore <globs>] [--ignore-path <path>] [--semi]',
       );
       process.exit(1);

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   },
   "bin": {
     "electron-markdownlint": "./dist/bin/markdownlint-cli-wrapper.js",
-    "electron-lint-markdown-links": "./dist/bin/lint-markdown-links.js",
-    "electron-lint-markdown-standard": "./dist/bin/lint-markdown-standard.js",
+    "lint-roller-markdown-links": "./dist/bin/lint-markdown-links.js",
+    "lint-roller-markdown-standard": "./dist/bin/lint-markdown-standard.js",
     "lint-roller-markdown-ts-check": "./dist/bin/lint-markdown-ts-check.js"
   },
   "files": [

--- a/tests/__snapshots__/lint-roller-markdown-standard.spec.ts.snap
+++ b/tests/__snapshots__/lint-roller-markdown-standard.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`electron-lint-markdown-standard can detect errors in code blocks 1`] = `
+exports[`lint-roller-markdown-standard can detect errors in code blocks 1`] = `
 "
    dirty.md
          6:1:      Unexpected var, use let or const instead.
@@ -28,7 +28,7 @@ There are 20 errors in '<root>'
 "
 `;
 
-exports[`electron-lint-markdown-standard can fix cleanable errors with --fix option 1`] = `
+exports[`lint-roller-markdown-standard can fix cleanable errors with --fix option 1`] = `
 "# The Cleanable Readme
 
 This is a markdown file with some javascript code blocks in it.
@@ -105,7 +105,7 @@ and wrapped arrays:
 "
 `;
 
-exports[`electron-lint-markdown-standard outputs uncleanable errors with --fix option 1`] = `
+exports[`lint-roller-markdown-standard outputs uncleanable errors with --fix option 1`] = `
 "# The Dirty Readme
 
 This is a markdown file with some javascript code blocks in it.

--- a/tests/lint-roller-markdown-links.spec.ts
+++ b/tests/lint-roller-markdown-links.spec.ts
@@ -11,7 +11,7 @@ function runLintMarkdownLinks(...args: string[]) {
   );
 }
 
-describe('electron-lint-markdown-links', () => {
+describe('lint-roller-markdown-links', () => {
   it('should catch broken internal links', () => {
     const { status, stdout } = runLintMarkdownLinks(
       '--root',

--- a/tests/lint-roller-markdown-standard.spec.ts
+++ b/tests/lint-roller-markdown-standard.spec.ts
@@ -13,7 +13,7 @@ function runLintMarkdownStandard(...args: string[]) {
   );
 }
 
-describe('electron-lint-markdown-standard', () => {
+describe('lint-roller-markdown-standard', () => {
   it('should run clean when there are no errors', () => {
     const { status } = runLintMarkdownStandard('--root', FIXTURES_DIR, 'clean.md');
 


### PR DESCRIPTION
Chained on top of #57.

The binaries which aren't Electron-specific (everything except `electron-markdownlint` which is just a wrapper to add our default rules) are renamed with `lint-roller-` prefix so that they're generic and aren't confusing to use in other projects.