### PR TITLE
feat: markdownlint rule to disallow opening curly braces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 markdownlint-rules/emd002.js
+markdownlint-rules/emd003.js

--- a/configs/markdownlint.json
+++ b/configs/markdownlint.json
@@ -24,5 +24,6 @@
   },
   "single-h1": false,
   "no-inline-html": false,
-  "no-angle-brackets": false
+  "no-angle-brackets": false,
+  "no-curly-braces": false
 }

--- a/markdownlint-rules/emd003.mjs
+++ b/markdownlint-rules/emd003.mjs
@@ -1,0 +1,46 @@
+import { addError, filterTokens } from 'markdownlint/helpers';
+
+import { fromMarkdown } from 'mdast-util-from-markdown';
+import { visit } from 'unist-util-visit';
+
+export const names = ['EMD003', 'no-curly-braces'];
+export const description = 'No unescaped opening curly braces in text (does not play nice with MDX)';
+export const tags = ['braces'];
+
+const UNESCAPED_REGEX = /(?<!\\){/g;
+
+function EMD003(params, onError) {
+  filterTokens(params, 'inline', (token) => {
+    for (const childToken of token.children) {
+      // childToken.line has the raw content, but may also contain
+      // more content than just childToken.content. Since we need
+      // the raw content to detect escaped curly braces, parse
+      // the raw content of any match a second time to avoid any
+      // false positives.
+      if (
+        childToken.type === 'text' &&
+        childToken.markup !== '&#123;' &&
+        childToken.content.includes('{') &&
+        childToken.line.match(UNESCAPED_REGEX) !== null
+      ) {
+        // The AST produced by mdast is easier to work with here
+        // since it gives position data within the line
+        const tree = fromMarkdown(childToken.line);
+
+        visit(
+          tree,
+          (node) => node.type === 'text',
+          (node) => {
+            const rawContent = childToken.line.slice(node.position.start.offset, node.position.end.offset);
+
+            if (rawContent.match(UNESCAPED_REGEX) !== null) {
+              addError(onError, token.lineNumber, 'Unescaped opening curly brace');
+            }
+          },
+        );
+      }
+    }
+  });
+};
+
+export { EMD003 as function };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "lib": "lib"
   },
   "scripts": {
-    "build": "tsc && esbuild --platform=node --target=node14 --format=cjs --bundle --outfile=markdownlint-rules/emd002.js markdownlint-rules/emd002.mjs",
+    "build": "tsc && yarn run build:emd002 && yarn run build:emd003",
+    "build:emd002": "esbuild --platform=node --target=node14 --format=cjs --bundle --outfile=markdownlint-rules/emd002.js markdownlint-rules/emd002.mjs",
+    "build:emd003": "esbuild --platform=node --target=node14 --format=cjs --bundle --outfile=markdownlint-rules/emd003.js markdownlint-rules/emd003.mjs",
     "prepublishOnly": "yarn run build",
     "lint:eslint": "eslint \"{bin,lib,markdownlint-rules,tests}/**/*.{js,ts}\"",
     "lint:eslint:fix": "eslint --fix \"{bin,lib,markdownlint-rules,tests}/**/*.{js,ts}\"",

--- a/tests/__snapshots__/electron-markdownlint.spec.ts.snap
+++ b/tests/__snapshots__/electron-markdownlint.spec.ts.snap
@@ -6,3 +6,8 @@ exports[`electron-markdownlint should not allow opening angle brackets if EMD002
 <root>angle-brackets.md:127 EMD002/no-angle-brackets No unescaped opening angle brackets in text (does not play nice with MDX) [Unescaped opening angle bracket]
 "
 `;
+
+exports[`electron-markdownlint should not allow opening curly braces if EMD003 enabled 1`] = `
+"<root>curly-braces.md:1 EMD003/no-curly-braces No unescaped opening curly braces in text (does not play nice with MDX) [Unescaped opening curly brace]
+"
+`;

--- a/tests/electron-markdownlint.spec.ts
+++ b/tests/electron-markdownlint.spec.ts
@@ -73,4 +73,46 @@ describe('electron-markdownlint', () => {
     expect(stdout).toBe('');
     expect(status).toEqual(0);
   });
+
+  it('should not allow opening curly braces if EMD003 enabled', () => {
+    const { status, stderr, stdout } = cp.spawnSync(
+      process.execPath,
+      [
+        path.resolve(__dirname, '../dist/bin/markdownlint-cli-wrapper.js'),
+        '--enable',
+        'EMD003',
+        '--',
+        path.resolve(FIXTURES_DIR, 'curly-braces.md'),
+      ],
+      { stdio: 'pipe', encoding: 'utf-8' },
+    );
+
+    let fixturesRoot = `${FIXTURES_DIR}${path.sep}`;
+
+    if (os.platform() === 'win32') {
+      fixturesRoot = fixturesRoot.replace(/\\/g, '\\\\');
+    }
+
+    expect(stderr.replace(new RegExp(fixturesRoot, 'g'), '<root>')).toMatchSnapshot();
+    expect(stdout).toBe('');
+    expect(status).toEqual(1);
+  });
+
+  it('should allow escaped opening curly braces if EMD003 enabled', () => {
+    const { status, stderr, stdout } = cp.spawnSync(
+      process.execPath,
+      [
+        path.resolve(__dirname, '../dist/bin/markdownlint-cli-wrapper.js'),
+        '--enable',
+        'EMD003',
+        '--',
+        path.resolve(FIXTURES_DIR, 'escaped-curly-braces.md'),
+      ],
+      { stdio: 'pipe', encoding: 'utf-8' },
+    );
+
+    expect(stderr).toBe('');
+    expect(stdout).toBe('');
+    expect(status).toEqual(0);
+  });
 });

--- a/tests/fixtures/curly-braces.md
+++ b/tests/fixtures/curly-braces.md
@@ -1,0 +1,8 @@
+Consider a normal window with an HD video player and associated controls.
+Perhaps there are 15 pixels of controls on the left edge, 25 pixels of controls
+on the right edge and 50 pixels of controls below the player. In order to
+maintain a 16:9 aspect ratio (standard aspect ratio for HD @1920x1080) within
+the player itself we would call this function with arguments of 16/9 and
+{ width: 40, height: 50 }. The second argument doesn't care where the extra width and height
+are within the content view--only that they exist. Sum any extra width and
+height areas you have within the overall content view.

--- a/tests/fixtures/escaped-curly-braces.md
+++ b/tests/fixtures/escaped-curly-braces.md
@@ -1,0 +1,8 @@
+Consider a normal window with an HD video player and associated controls.
+Perhaps there are 15 pixels of controls on the left edge, 25 pixels of controls
+on the right edge and 50 pixels of controls below the player. In order to
+maintain a 16:9 aspect ratio (standard aspect ratio for HD @1920x1080) within
+the player itself we would call this function with arguments of 16/9 and
+\{ width: 40, height: 50 \}. The second argument doesn't care where the extra width and height
+are within the content view--only that they exist. Sum any extra width and
+height areas you have within the overall content view.


### PR DESCRIPTION
[MDX v3 doesn't play nice with unescaped curly braces](https://mdxjs.com/docs/what-is-mdx/#expressions), so provide a rule to help us keep them out of the docs unless they're properly escaped.