### PR TITLE
feat: export all markdownlint rules

### DIFF
--- a/bin/markdownlint-cli-wrapper.ts
+++ b/bin/markdownlint-cli-wrapper.ts
@@ -9,7 +9,7 @@ if (require.main === module) {
     [
       require.resolve('markdownlint-cli'),
       '-r',
-      path.resolve(__dirname, '../../markdownlint-rules'),
+      path.resolve(__dirname, '../../markdownlint-rules/index.js'),
       ...process.argv.slice(2),
     ],
     { stdio: 'inherit' },

--- a/markdownlint-rules/index.js
+++ b/markdownlint-rules/index.js
@@ -1,0 +1,4 @@
+const EMD002 = require('./emd002.js');
+const EMD003 = require('./emd003.js');
+
+module.exports = [EMD002, EMD003];


### PR DESCRIPTION
This will let rules be easily used from this package in a config without listing each rule. In a future breaking version `electron-markdownlint` will be removed.