### PR TITLE
feat(api-history): `--check-descriptions`

### DIFF
--- a/bin/lint-markdown-api-history.ts
+++ b/bin/lint-markdown-api-history.ts
@@ -254,8 +254,7 @@ async function main(
           for (const [matchedLine, matchedGroup] of possibleDescription) {
             const trimmedMatchedGroup = matchedGroup.trim();
             const isMatchedGroupInsideQuotes =
-              (trimmedMatchedGroup.startsWith('"') && trimmedMatchedGroup.endsWith('"')) ||
-              (trimmedMatchedGroup.startsWith("'") && trimmedMatchedGroup.endsWith("'"));
+              trimmedMatchedGroup.startsWith('"') && trimmedMatchedGroup.endsWith('"');
 
             if (isMatchedGroupInsideQuotes) continue;
 

--- a/bin/lint-markdown-api-history.ts
+++ b/bin/lint-markdown-api-history.ts
@@ -179,7 +179,7 @@ async function main(
 
       const possibleHistoryBlocks = await findPossibleApiHistoryBlocks(documentText);
 
-      for (const possibleHistoryBlock of possibleHistoryBlocks) {
+      historyBlockForLoop: for (const possibleHistoryBlock of possibleHistoryBlocks) {
         historyBlockCounter++;
 
         const {
@@ -256,22 +256,23 @@ async function main(
             const isMatchedGroupInsideQuotes =
               trimmedMatchedGroup.startsWith('"') && trimmedMatchedGroup.endsWith('"');
 
-            if (isMatchedGroupInsideQuotes) continue;
+            if (!isMatchedGroupInsideQuotes) {
+              console.error(
+                'Error occurred while parsing Markdown document:\n\n' +
+                  `'${filepath}'\n\n` +
+                  'Possible description field is not surrounded by double quotes.\n\n' +
+                  'This might cause issues when parsing the YAML (might not throw an error)\n\n' +
+                  'Matched group:\n\n' +
+                  `${matchedGroup}\n\n` +
+                  'Matched line:\n\n' +
+                  `${matchedLine}\n\n` +
+                  'API history block:\n\n' +
+                  `${possibleHistoryBlock.value}\n`,
+              );
+              errorCounter++;
+              continue historyBlockForLoop;
+            }
 
-            console.error(
-              'Error occurred while parsing Markdown document:\n\n' +
-                `'${filepath}'\n\n` +
-                'Possible description field is not surrounded by double quotes.\n\n' +
-                'This might cause issues when parsing the YAML (might not throw an error)\n\n' +
-                'Matched group:\n\n' +
-                `${matchedGroup}\n\n` +
-                'Matched line:\n\n' +
-                `${matchedLine}\n\n` +
-                'API history block:\n\n' +
-                `${possibleHistoryBlock.value}\n`,
-            );
-            errorCounter++;
-            continue;
           }
         }
 

--- a/bin/lint-markdown-api-history.ts
+++ b/bin/lint-markdown-api-history.ts
@@ -270,9 +270,9 @@ async function main(
                   `${possibleHistoryBlock.value}\n`,
               );
               errorCounter++;
+              // Behold, one of the rare occasions when a labeled statement is useful.
               continue historyBlockForLoop;
             }
-
           }
         }
 

--- a/tests/fixtures/api-history-description-invalid.md
+++ b/tests/fixtures/api-history-description-invalid.md
@@ -1,0 +1,17 @@
+#### `win.setTrafficLightPosition(position)` _macOS_ _Deprecated_
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/22533
+changes:
+  - pr-url: https://github.com/electron/electron/pull/26789
+    description: Made `trafficLightPosition` option work for `customButtonOnHover`.
+deprecated:
+  - pr-url: https://github.com/electron/electron/pull/37094
+    breaking-changes-header: deprecated-browserwindowsettrafficlightpositionposition
+```
+-->
+
+Set a custom position for the traffic light buttons in frameless window.
+Passing `{ x: 0, y: 0 }` will reset the position to default.

--- a/tests/fixtures/api-history-format-invalid.md
+++ b/tests/fixtures/api-history-format-invalid.md
@@ -7,7 +7,7 @@ added:
   - pr-url: https://github.com/electron/electron/pull/22533
 changes:
   - pr-url: https://github.com/electron/electron/pull/26789
-    description: Made `trafficLightPosition` option work for `customButtonOnHover`.
+    description: "Made `trafficLightPosition` option work for `customButtonOnHover`."
 deprecated:
   - pr-url: https://github.com/electron/electron/pull/37094
     breaking-changes-header: deprecated-browserwindowsettrafficlightpositionposition

--- a/tests/fixtures/api-history-heading-missing.md
+++ b/tests/fixtures/api-history-heading-missing.md
@@ -6,7 +6,7 @@ added:
   - pr-url: https://github.com/electron/electron/pull/22533
 changes:
   - pr-url: https://github.com/electron/electron/pull/26789
-    description: Made `trafficLightPosition` option work for `customButtonOnHover`.
+    description: "Made `trafficLightPosition` option work for `customButtonOnHover`."
 deprecated:
   - pr-url: https://github.com/electron/electron/pull/37094
     breaking-changes-header: deprecated-missing-header

--- a/tests/fixtures/api-history-placement-invalid.md
+++ b/tests/fixtures/api-history-placement-invalid.md
@@ -9,7 +9,7 @@ added:
   - pr-url: https://github.com/electron/electron/pull/22533
 changes:
   - pr-url: https://github.com/electron/electron/pull/26789
-    description: Made `trafficLightPosition` option work for `customButtonOnHover`.
+    description: "Made `trafficLightPosition` option work for `customButtonOnHover`."
 deprecated:
   - pr-url: https://github.com/electron/electron/pull/37094
     breaking-changes-header: deprecated-browserwindowsettrafficlightpositionposition

--- a/tests/fixtures/api-history-schema-invalid.md
+++ b/tests/fixtures/api-history-schema-invalid.md
@@ -6,7 +6,7 @@ added:
   - pr-url: https://github.com/electron/electron/pull/22533
 changes:
   - pr-url: https://github.com/electron/electron/pull/26789
-    description: Ma
+    description: "Ma"
 deprecated:
   - pr-url: https://github.com/electron/electron/pull/37094
     breaking-changes-header: deprecated-browserwindowsettrafficlightpositionposition

--- a/tests/fixtures/api-history-string-invalid.md
+++ b/tests/fixtures/api-history-string-invalid.md
@@ -5,10 +5,10 @@
 added:
   - pr-url: https://github.com/electron/electron/pull/22533
 changes:
-  - pr-url: https://github.com/electron/electron/pull/26789
-    description: Made `trafficLightPosition` option work for `customButtonOnHover`:
+  - pr-url: https://github.com/electron/electron/pull/26789:
+    description: "Made `trafficLightPosition` option work for `customButtonOnHover`"
   - pr-url: https://github.com/electron/electron/pull/1337
-    description: "Made `trafficLightPosition` option work for `customButtonOnHover`:"
+    description: "Made `trafficLightPosition` option work for `customButtonOnHover`"
 ```
 -->
 

--- a/tests/fixtures/api-history-valid.md
+++ b/tests/fixtures/api-history-valid.md
@@ -6,7 +6,7 @@ added:
   - pr-url: https://github.com/electron/electron/pull/22533
 changes:
   - pr-url: https://github.com/electron/electron/pull/26789
-    description: Made `trafficLightPosition` option work for `customButtonOnHover`.
+    description: "Made `trafficLightPosition` option work for `customButtonOnHover`."
 deprecated:
   - pr-url: https://github.com/electron/electron/pull/37094
     breaking-changes-header: deprecated-browserwindowsettrafficlightpositionposition

--- a/tests/fixtures/api-history-yaml-invalid.md
+++ b/tests/fixtures/api-history-yaml-invalid.md
@@ -5,7 +5,7 @@
 added: pr-url: https://github.com/electron/electron/pull/22533
 changes:
   - pr-url: https://github.com/electron/electron/pull/26789
-    description: Made `trafficLightPosition` option work for `customButtonOnHover`.
+    description: "Made `trafficLightPosition` option work for `customButtonOnHover`."
 deprecated:
   - pr-url: https://github.com/electron/electron/pull/37094
     breaking-changes-header: deprecated-browserwindowsettrafficlightpositionposition

--- a/tests/lint-roller-markdown-api-history.spec.ts
+++ b/tests/lint-roller-markdown-api-history.spec.ts
@@ -72,7 +72,7 @@ async function generateRandomApiDocuments(): Promise<GenerateRandomApiDocumentsR
 
     if (isError) {
       // Will cause a warning but not a yaml parse error
-      return { isError, stringWarnChar: '$' };
+      return { isError, stringWarnChar: '#' };
     } else {
       return { isError, stringWarnChar: '' };
     }
@@ -117,10 +117,10 @@ async function generateRandomApiDocuments(): Promise<GenerateRandomApiDocumentsR
         `  - pr-url: ${generateRandomPrUrl()}\n` +
         'changes:\n' +
         `  - pr-url: ${generateRandomPrUrl()}\n` +
-        `    description: ${stringWarnChar}Made \`trafficLightPosition\` work for \`customButtonOnHover\`.\n` +
+        `    description: "Made \`trafficLightPosition\` work for \`customButtonOnHover\`."\n` +
         'deprecated:\n' +
         `  - pr-url: ${generateRandomPrUrl()}\n` +
-        `    breaking-changes-header: ${generateRandomBreakingHeadingId()}\n` +
+        `    breaking-changes-header: ${generateRandomBreakingHeadingId()} ${stringWarnChar}\n` +
         '```\n' +
         '-->\n\n' +
         'Set a custom position for the traffic light buttons in frameless window.\n' +
@@ -161,6 +161,7 @@ describe('lint-roller-markdown-api-history', () => {
       BREAKING_CHANGES_FILE,
       '--check-placement',
       '--check-strings',
+      '--check-descriptions',
       'api-history-valid.md',
     );
 
@@ -183,6 +184,7 @@ describe('lint-roller-markdown-api-history', () => {
       API_HISTORY_SCHEMA,
       '--check-placement',
       '--check-strings',
+      '--check-descriptions',
       'api-history-yaml-invalid.md',
     );
 
@@ -205,6 +207,7 @@ describe('lint-roller-markdown-api-history', () => {
       API_HISTORY_SCHEMA,
       '--check-placement',
       '--check-strings',
+      '--check-descriptions',
       'api-history-schema-invalid.md',
     );
 
@@ -227,6 +230,7 @@ describe('lint-roller-markdown-api-history', () => {
       API_HISTORY_SCHEMA,
       '--check-placement',
       '--check-strings',
+      '--check-descriptions',
       'api-history-format-invalid.md',
     );
 
@@ -251,6 +255,7 @@ describe('lint-roller-markdown-api-history', () => {
       BREAKING_CHANGES_FILE,
       '--check-placement',
       '--check-strings',
+      '--check-descriptions',
       'api-history-heading-missing.md',
     );
 
@@ -275,6 +280,7 @@ describe('lint-roller-markdown-api-history', () => {
       BREAKING_CHANGES_FILE,
       '--check-placement',
       '--check-strings',
+      '--check-descriptions',
       'api-history-placement-invalid.md',
     );
 
@@ -299,6 +305,7 @@ describe('lint-roller-markdown-api-history', () => {
       BREAKING_CHANGES_FILE,
       '--check-placement',
       '--check-strings',
+      '--check-descriptions',
       'api-history-string-invalid.md',
     );
 
@@ -322,6 +329,7 @@ describe('lint-roller-markdown-api-history', () => {
       API_HISTORY_SCHEMA,
       '--check-placement',
       '--check-strings',
+      '--check-descriptions',
       '--ignore',
       '**/api-history-yaml-invalid.md',
       '{api-history-valid,api-history-yaml-invalid}.md',
@@ -344,6 +352,7 @@ describe('lint-roller-markdown-api-history', () => {
       API_HISTORY_SCHEMA,
       '--check-placement',
       '--check-strings',
+      '--check-descriptions',
       '--ignore',
       '**/api-history-valid.md',
       '--ignore',
@@ -370,6 +379,7 @@ describe('lint-roller-markdown-api-history', () => {
       resolve(FIXTURES_DIR, 'ignorepaths'),
       '--check-placement',
       '--check-strings',
+      '--check-descriptions',
       '{api-history-valid,api-history-yaml-invalid}.md',
     );
 
@@ -392,6 +402,7 @@ describe('lint-roller-markdown-api-history', () => {
       BREAKING_CHANGES_FILE,
       '--check-placement',
       '--check-strings',
+      '--check-descriptions',
       '{api-history-valid,api-history-yaml-invalid,api-history-heading-missing}.md',
     );
 
@@ -426,6 +437,7 @@ describe('lint-roller-markdown-api-history', () => {
       BREAKING_CHANGES_FILE,
       '--check-placement',
       '--check-strings',
+      '--check-descriptions',
       '*.md',
     );
 

--- a/tests/lint-roller-markdown-api-history.spec.ts
+++ b/tests/lint-roller-markdown-api-history.spec.ts
@@ -321,6 +321,31 @@ describe('lint-roller-markdown-api-history', () => {
     expect(status).toEqual(1);
   });
 
+  it('should not run clean when there are description errors', () => {
+    const { status, stdout, stderr } = runLintMarkdownApiHistory(
+      '--root',
+      FIXTURES_DIR,
+      '--schema',
+      API_HISTORY_SCHEMA,
+      '--breaking-changes-file',
+      BREAKING_CHANGES_FILE,
+      '--check-placement',
+      '--check-strings',
+      '--check-descriptions',
+      'api-history-description-invalid.md',
+    );
+
+    expect(stderr).toMatch(/Possible description field is not surrounded by double quotes./);
+
+    const [blocks, documents, errors, warnings] = stdoutRegex.exec(stdout)?.slice(1, 5) ?? [];
+
+    expect(Number(blocks)).toEqual(1);
+    expect(Number(documents)).toEqual(1);
+    expect(Number(errors)).toEqual(1);
+    expect(Number(warnings)).toEqual(0);
+    expect(status).toEqual(1);
+  });
+
   it('can ignore a glob', () => {
     const { status, stdout } = runLintMarkdownApiHistory(
       '--root',


### PR DESCRIPTION
Resolves: #78

Throws error if description field is not surrounded by double quotation marks.

@dsanders11 @erickzhao @VerteDinde 