### PR TITLE
chore: restore markdownlint test coverage

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "extends": "./configs/markdownlint.json"
+  }
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "./configs/markdownlint.json"
-}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint": "^8.54.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-node": "^11.1.0",
-    "markdownlint-cli2": "^0.14.0",
+    "markdownlint-cli2": "^0.13.0",
     "prettier": "^3.2.5",
     "typescript": "^5.4.5",
     "vitest": "^2.1.4"

--- a/tests/__snapshots__/markdownlint-cli2.spec.ts.snap
+++ b/tests/__snapshots__/markdownlint-cli2.spec.ts.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`markdownlint-cli2 > should not allow newlines in link text if EMD004 enabled 1`] = `
+"tests/fixtures/newline-in-link-text.md:1 EMD004/no-newline-in-links Newlines inside link text
+tests/fixtures/newline-in-link-text.md:4 EMD004/no-newline-in-links Newlines inside link text
+tests/fixtures/newline-in-link-text.md:7 EMD004/no-newline-in-links Newlines inside link text
+tests/fixtures/newline-in-link-text.md:10 EMD004/no-newline-in-links Newlines inside link text
+"
+`;
+
+exports[`markdownlint-cli2 > should not allow opening angle brackets if EMD002 enabled 1`] = `
+"tests/fixtures/angle-brackets.md:3:13 EMD002/no-angle-brackets No unescaped opening angle brackets in text (does not play nice with MDX) [Unescaped opening angle bracket]
+tests/fixtures/angle-brackets.md:9:16 EMD002/no-angle-brackets No unescaped opening angle brackets in text (does not play nice with MDX) [Unescaped opening angle bracket]
+tests/fixtures/angle-brackets.md:127:21 EMD002/no-angle-brackets No unescaped opening angle brackets in text (does not play nice with MDX) [Unescaped opening angle bracket]
+"
+`;
+
+exports[`markdownlint-cli2 > should not allow opening curly braces if EMD003 enabled 1`] = `
+"tests/fixtures/curly-braces.md:6:1 EMD003/no-curly-braces No unescaped opening curly braces in text (does not play nice with MDX) [Unescaped opening curly brace]
+"
+`;

--- a/tests/markdownlint-cli2.spec.ts
+++ b/tests/markdownlint-cli2.spec.ts
@@ -24,11 +24,11 @@ async function runMarkdownlint(args: string[], configOptions: Record<string, unk
 
   args.push('--config', configFilePath);
 
-  return cp.spawnSync(
-    process.execPath,
-    [path.resolve(__dirname, '../node_modules/.bin/markdownlint-cli2'), ...args],
-    { stdio: 'pipe', encoding: 'utf-8' },
-  );
+  return cp.spawnSync('npx', ['markdownlint-cli2', ...args], {
+    stdio: 'pipe',
+    encoding: 'utf-8',
+    shell: os.platform() === 'win32',
+  });
 }
 
 describe('markdownlint-cli2', () => {

--- a/tests/markdownlint-cli2.spec.ts
+++ b/tests/markdownlint-cli2.spec.ts
@@ -1,0 +1,119 @@
+import * as cp from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+
+let TEMP_CONFIG_DIR: string;
+
+async function runMarkdownlint(args: string[], configOptions: Record<string, unknown> = {}) {
+  const configFilePath = path.resolve(TEMP_CONFIG_DIR, `.markdownlint-cli2.jsonc`);
+  await fs.writeFile(
+    configFilePath,
+    JSON.stringify({
+      config: {
+        extends: path.resolve(__dirname, '../configs/markdownlint.json'),
+        ...configOptions,
+      },
+      customRules: [path.resolve(__dirname, '../markdownlint-rules/index.js')],
+    }),
+  );
+
+  args.push('--config', configFilePath);
+
+  return cp.spawnSync(
+    process.execPath,
+    [path.resolve(__dirname, '../node_modules/.bin/markdownlint-cli2'), ...args],
+    { stdio: 'pipe', encoding: 'utf-8' },
+  );
+}
+
+describe('markdownlint-cli2', () => {
+  beforeAll(async () => {
+    TEMP_CONFIG_DIR = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'lint-roller-markdownlint-cli2-test-'),
+    );
+  });
+
+  afterAll(async () => {
+    await fs.rm(TEMP_CONFIG_DIR, { recursive: true, force: true });
+  });
+
+  it('should not allow shortcut links', async () => {
+    const { status, stderr } = await runMarkdownlint([
+      path.resolve(FIXTURES_DIR, 'shortcut-links.md'),
+    ]);
+
+    expect(stderr).toContain('MD054/link-image-style');
+    expect(status).toEqual(1);
+  });
+
+  it('should allow GitHub alert syntax', async () => {
+    const { status } = await runMarkdownlint([path.resolve(FIXTURES_DIR, 'github-alerts.md')]);
+
+    expect(status).toEqual(0);
+  });
+
+  it('should not allow opening angle brackets if EMD002 enabled', async () => {
+    const { status, stderr } = await runMarkdownlint(
+      [path.resolve(FIXTURES_DIR, 'angle-brackets.md')],
+      { EMD002: true },
+    );
+
+    expect(stderr).toMatchSnapshot();
+    expect(status).toEqual(1);
+  });
+
+  it('should allow escaped opening angle brackets if EMD002 enabled', async () => {
+    const { status, stderr } = await runMarkdownlint(
+      [path.resolve(FIXTURES_DIR, 'escaped-angle-brackets.md')],
+      { EMD002: true },
+    );
+
+    expect(stderr).toBe('');
+    expect(status).toEqual(0);
+  });
+
+  it('should not allow opening curly braces if EMD003 enabled', async () => {
+    const { status, stderr } = await runMarkdownlint(
+      [path.resolve(FIXTURES_DIR, 'curly-braces.md')],
+      { EMD003: true },
+    );
+
+    expect(stderr).toMatchSnapshot();
+    expect(status).toEqual(1);
+  });
+
+  it('should allow escaped opening curly braces if EMD003 enabled', async () => {
+    const { status, stderr } = await runMarkdownlint(
+      [path.resolve(FIXTURES_DIR, 'escaped-curly-braces.md')],
+      { EMD003: true },
+    );
+
+    expect(stderr).toBe('');
+    expect(status).toEqual(0);
+  });
+
+  it('should not allow newlines in link text if EMD004 enabled', async () => {
+    const { status, stderr } = await runMarkdownlint(
+      [path.resolve(FIXTURES_DIR, 'newline-in-link-text.md')],
+      { EMD004: true, 'no-space-in-links': false },
+    );
+
+    expect(stderr).toMatchSnapshot();
+    expect(status).toEqual(1);
+  });
+
+  it('should allow newlines in link text if EMD004 not enabled', async () => {
+    const { status, stderr } = await runMarkdownlint(
+      [path.resolve(FIXTURES_DIR, 'newline-in-link-text.md')],
+      { EMD004: false, 'no-space-in-links': false },
+    );
+
+    expect(stderr).toBe('');
+    expect(status).toEqual(0);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -860,7 +860,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.3:
+braces@^3.0.2, braces@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
@@ -1747,10 +1747,10 @@ globalthis@^1.0.3:
   dependencies:
     define-properties "^1.1.3"
 
-globby@14.0.2:
-  version "14.0.2"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-14.0.2.tgz#06554a54ccfe9264e5a9ff8eded46aa1e306482f"
-  integrity sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==
+globby@14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-14.0.1.tgz#a1b44841aa7f4c6d8af2bc39951109d77301959b"
+  integrity sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==
   dependencies:
     "@sindresorhus/merge-streams" "^2.1.0"
     fast-glob "^3.3.2"
@@ -2115,10 +2115,10 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-jsonc-parser@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.3.1.tgz#f2a524b4f7fd11e3d791e559977ad60b98b798b4"
-  integrity sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==
+jsonc-parser@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.1.tgz#031904571ccf929d7670ee8c547545081cb37f1a"
+  integrity sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.3"
@@ -2240,35 +2240,35 @@ markdown-it@^13.0.1:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-markdownlint-cli2-formatter-default@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.5.tgz#b8fde4e127f9a9c0596e6d45eed352dd0aa0ff98"
-  integrity sha512-4XKTwQ5m1+Txo2kuQ3Jgpo/KmnG+X90dWt4acufg6HVGadTUG5hzHF/wssp9b5MBYOMCnZ9RMPaU//uHsszF8Q==
+markdownlint-cli2-formatter-default@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.4.tgz#81e26b0a50409c0357c6f0d38d8246946b236fab"
+  integrity sha512-xm2rM0E+sWgjpPn1EesPXx5hIyrN2ddUnUwnbCsD/ONxYtw3PX6LydvdH6dciWAoFDpwzbHM1TO7uHfcMd6IYg==
 
-markdownlint-cli2@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/markdownlint-cli2/-/markdownlint-cli2-0.14.0.tgz#57dd69224c6859d64d79b6e88163208e170dc310"
-  integrity sha512-2cqdWy56frU2FTpbuGb83mEWWYuUIYv6xS8RVEoUAuKNw/hXPar2UYGpuzUhlFMngE8Omaz4RBH52MzfRbGshw==
+markdownlint-cli2@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli2/-/markdownlint-cli2-0.13.0.tgz#691cab01994295b4b8c87aa0485c0b1e0f792289"
+  integrity sha512-Pg4nF7HlopU97ZXtrcVISWp3bdsuc5M0zXyLp2/sJv2zEMlInrau0ZKK482fQURzVezJzWBpNmu4u6vGAhij+g==
   dependencies:
-    globby "14.0.2"
+    globby "14.0.1"
     js-yaml "4.1.0"
-    jsonc-parser "3.3.1"
-    markdownlint "0.35.0"
-    markdownlint-cli2-formatter-default "0.0.5"
-    micromatch "4.0.8"
+    jsonc-parser "3.2.1"
+    markdownlint "0.34.0"
+    markdownlint-cli2-formatter-default "0.0.4"
+    micromatch "4.0.5"
 
-markdownlint-micromark@0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/markdownlint-micromark/-/markdownlint-micromark-0.1.10.tgz#a77a1a70adad9eac18ff412baf36a0c2189875d7"
-  integrity sha512-no5ZfdqAdWGxftCLlySHSgddEjyW4kui4z7amQcGsSKfYC5v/ou+8mIQVyg9KQMeEZLNtz9OPDTj7nnTnoR4FQ==
+markdownlint-micromark@0.1.9:
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/markdownlint-micromark/-/markdownlint-micromark-0.1.9.tgz#4876996b60d4dceb3a02f4eee2d3a366eb9569fa"
+  integrity sha512-5hVs/DzAFa8XqYosbEAEg6ok6MF2smDj89ztn9pKkCtdKHVdPQuGMH7frFfYL9mLkvfFe4pTyAMffLbjf3/EyA==
 
-markdownlint@0.35.0:
-  version "0.35.0"
-  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.35.0.tgz#8189347fef3550045de78a96c52a7f45c2a4f91e"
-  integrity sha512-wgp8yesWjFBL7bycA3hxwHRdsZGJhjhyP1dSxKVKrza0EPFYtn+mHtkVy6dvP1kGSjovyG5B8yNP6Frj0UFUJg==
+markdownlint@0.34.0:
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.34.0.tgz#bbc2047c952d1644269009a69ba227ed597b23fa"
+  integrity sha512-qwGyuyKwjkEMOJ10XN6OTKNOVYvOIi35RNvDLNxTof5s8UmyGHlCdpngRHoRGNvQVGuxO3BJ7uNSgdeX166WXw==
   dependencies:
     markdown-it "14.1.0"
-    markdownlint-micromark "0.1.10"
+    markdownlint-micromark "0.1.9"
 
 mdast-util-from-markdown@^1.3.0:
   version "1.3.0"
@@ -2505,7 +2505,15 @@ micromark@^3.0.0:
     micromark-util-types "^1.0.1"
     uvu "^0.5.0"
 
-micromatch@4.0.8, micromatch@^4.0.4:
+micromatch@4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+  dependencies:
+    braces "^3.0.2"
+    picomatch "^2.3.1"
+
+micromatch@^4.0.4:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==


### PR DESCRIPTION
I got too overzealous with #91 and also removed test coverage. 🤦

This also downgrades to `markdownlint@0.34.0` (via `markdownlint-cli2@^0.13.0`) as the 0.35.0 release has a breaking change for our custom rules which needs to be rectified in a follow-up PR.