### PR TITLE
feat: custom rule compat with markdownlint 0.35 [skip release]

### DIFF
--- a/markdownlint-rules/emd002.mjs
+++ b/markdownlint-rules/emd002.mjs
@@ -1,5 +1,3 @@
-import { addError, filterTokens } from 'markdownlint/helpers';
-
 import { fromMarkdown } from 'mdast-util-from-markdown';
 import { visit } from 'unist-util-visit';
 
@@ -11,7 +9,9 @@ export const tags = ['brackets'];
 const UNESCAPED_REGEX = /(?<!\\)<(?!\s)/g;
 
 function EMD002(params, onError) {
-  filterTokens(params, 'inline', (token) => {
+  const tokens = params.parsers.markdownit.tokens.filter((token) => token.type === 'inline');
+
+  for (const token of tokens) {
     for (const childToken of token.children) {
       // childToken.line has the raw content, but may also contain
       // more content than just childToken.content. Since we need
@@ -41,19 +41,17 @@ function EMD002(params, onError) {
             const matches = rawContent.matchAll(UNESCAPED_REGEX);
 
             for (const match of matches) {
-              addError(
-                onError,
-                childToken.lineNumber,
-                'Unescaped opening angle bracket',
-                undefined,
-                [node.position.start.offset + 1 + match.index, 1],
-              );
+              onError({
+                lineNumber: childToken.lineNumber,
+                detail: 'Unescaped opening angle bracket',
+                range: [node.position.start.offset + 1 + match.index, 1],
+              });
             }
           },
         );
       }
     }
-  });
+  }
 }
 
 export { EMD002 as function };

--- a/markdownlint-rules/emd003.mjs
+++ b/markdownlint-rules/emd003.mjs
@@ -1,5 +1,3 @@
-import { addError, filterTokens } from 'markdownlint/helpers';
-
 import { fromMarkdown } from 'mdast-util-from-markdown';
 import { visit } from 'unist-util-visit';
 
@@ -11,7 +9,9 @@ export const tags = ['braces'];
 const UNESCAPED_REGEX = /(?<!\\){/g;
 
 function EMD003(params, onError) {
-  filterTokens(params, 'inline', (token) => {
+  const tokens = params.parsers.markdownit.tokens.filter((token) => token.type === 'inline');
+
+  for (const token of tokens) {
     for (const childToken of token.children) {
       // childToken.line has the raw content, but may also contain
       // more content than just childToken.content. Since we need
@@ -40,16 +40,17 @@ function EMD003(params, onError) {
             const matches = rawContent.matchAll(UNESCAPED_REGEX);
 
             for (const match of matches) {
-              addError(onError, childToken.lineNumber, 'Unescaped opening curly brace', undefined, [
-                node.position.start.offset + 1 + match.index,
-                1,
-              ]);
+              onError({
+                lineNumber: childToken.lineNumber,
+                detail: 'Unescaped opening curly brace',
+                range: [node.position.start.offset + 1 + match.index, 1],
+              });
             }
           },
         );
       }
     }
-  });
+  }
 }
 
 export { EMD003 as function };

--- a/markdownlint-rules/emd004.js
+++ b/markdownlint-rules/emd004.js
@@ -1,12 +1,12 @@
-const { addError, filterTokens } = require('markdownlint/helpers');
-
 module.exports = {
   names: ['EMD004', 'no-newline-in-links'],
   description: 'Newlines inside link text',
   tags: ['newline', 'links'],
   parser: 'markdownit',
   function: function EMD004(params, onError) {
-    filterTokens(params, 'inline', (token) => {
+    const tokens = params.parsers.markdownit.tokens.filter((token) => token.type === 'inline');
+
+    for (const token of tokens) {
       const { children } = token;
       let { lineNumber } = token;
       let inLink = false;
@@ -18,13 +18,13 @@ module.exports = {
           inLink = false;
         } else if (type === 'softbreak') {
           if (inLink) {
-            addError(onError, lineNumber);
+            onError({ lineNumber });
             break;
           } else {
             lineNumber++;
           }
         }
       }
-    });
+    }
   },
 };

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint": "^8.54.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-node": "^11.1.0",
-    "markdownlint-cli2": "^0.13.0",
+    "markdownlint-cli2": "^0.14.0",
     "prettier": "^3.2.5",
     "typescript": "^5.4.5",
     "vitest": "^2.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -860,7 +860,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.2, braces@^3.0.3:
+braces@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
@@ -1747,10 +1747,10 @@ globalthis@^1.0.3:
   dependencies:
     define-properties "^1.1.3"
 
-globby@14.0.1:
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-14.0.1.tgz#a1b44841aa7f4c6d8af2bc39951109d77301959b"
-  integrity sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==
+globby@14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-14.0.2.tgz#06554a54ccfe9264e5a9ff8eded46aa1e306482f"
+  integrity sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==
   dependencies:
     "@sindresorhus/merge-streams" "^2.1.0"
     fast-glob "^3.3.2"
@@ -2115,10 +2115,10 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-jsonc-parser@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.1.tgz#031904571ccf929d7670ee8c547545081cb37f1a"
-  integrity sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==
+jsonc-parser@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.3.1.tgz#f2a524b4f7fd11e3d791e559977ad60b98b798b4"
+  integrity sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.3"
@@ -2240,35 +2240,35 @@ markdown-it@^13.0.1:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-markdownlint-cli2-formatter-default@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.4.tgz#81e26b0a50409c0357c6f0d38d8246946b236fab"
-  integrity sha512-xm2rM0E+sWgjpPn1EesPXx5hIyrN2ddUnUwnbCsD/ONxYtw3PX6LydvdH6dciWAoFDpwzbHM1TO7uHfcMd6IYg==
+markdownlint-cli2-formatter-default@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.5.tgz#b8fde4e127f9a9c0596e6d45eed352dd0aa0ff98"
+  integrity sha512-4XKTwQ5m1+Txo2kuQ3Jgpo/KmnG+X90dWt4acufg6HVGadTUG5hzHF/wssp9b5MBYOMCnZ9RMPaU//uHsszF8Q==
 
-markdownlint-cli2@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/markdownlint-cli2/-/markdownlint-cli2-0.13.0.tgz#691cab01994295b4b8c87aa0485c0b1e0f792289"
-  integrity sha512-Pg4nF7HlopU97ZXtrcVISWp3bdsuc5M0zXyLp2/sJv2zEMlInrau0ZKK482fQURzVezJzWBpNmu4u6vGAhij+g==
+markdownlint-cli2@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli2/-/markdownlint-cli2-0.14.0.tgz#57dd69224c6859d64d79b6e88163208e170dc310"
+  integrity sha512-2cqdWy56frU2FTpbuGb83mEWWYuUIYv6xS8RVEoUAuKNw/hXPar2UYGpuzUhlFMngE8Omaz4RBH52MzfRbGshw==
   dependencies:
-    globby "14.0.1"
+    globby "14.0.2"
     js-yaml "4.1.0"
-    jsonc-parser "3.2.1"
-    markdownlint "0.34.0"
-    markdownlint-cli2-formatter-default "0.0.4"
-    micromatch "4.0.5"
+    jsonc-parser "3.3.1"
+    markdownlint "0.35.0"
+    markdownlint-cli2-formatter-default "0.0.5"
+    micromatch "4.0.8"
 
-markdownlint-micromark@0.1.9:
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/markdownlint-micromark/-/markdownlint-micromark-0.1.9.tgz#4876996b60d4dceb3a02f4eee2d3a366eb9569fa"
-  integrity sha512-5hVs/DzAFa8XqYosbEAEg6ok6MF2smDj89ztn9pKkCtdKHVdPQuGMH7frFfYL9mLkvfFe4pTyAMffLbjf3/EyA==
+markdownlint-micromark@0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/markdownlint-micromark/-/markdownlint-micromark-0.1.10.tgz#a77a1a70adad9eac18ff412baf36a0c2189875d7"
+  integrity sha512-no5ZfdqAdWGxftCLlySHSgddEjyW4kui4z7amQcGsSKfYC5v/ou+8mIQVyg9KQMeEZLNtz9OPDTj7nnTnoR4FQ==
 
-markdownlint@0.34.0:
-  version "0.34.0"
-  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.34.0.tgz#bbc2047c952d1644269009a69ba227ed597b23fa"
-  integrity sha512-qwGyuyKwjkEMOJ10XN6OTKNOVYvOIi35RNvDLNxTof5s8UmyGHlCdpngRHoRGNvQVGuxO3BJ7uNSgdeX166WXw==
+markdownlint@0.35.0:
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.35.0.tgz#8189347fef3550045de78a96c52a7f45c2a4f91e"
+  integrity sha512-wgp8yesWjFBL7bycA3hxwHRdsZGJhjhyP1dSxKVKrza0EPFYtn+mHtkVy6dvP1kGSjovyG5B8yNP6Frj0UFUJg==
   dependencies:
     markdown-it "14.1.0"
-    markdownlint-micromark "0.1.9"
+    markdownlint-micromark "0.1.10"
 
 mdast-util-from-markdown@^1.3.0:
   version "1.3.0"
@@ -2505,15 +2505,7 @@ micromark@^3.0.0:
     micromark-util-types "^1.0.1"
     uvu "^0.5.0"
 
-micromatch@4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
-  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
-  dependencies:
-    braces "^3.0.2"
-    picomatch "^2.3.1"
-
-micromatch@^4.0.4:
+micromatch@4.0.8, micromatch@^4.0.4:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==


### PR DESCRIPTION
The `filterTokens` helper went away and `addError` is just a very thing wrapper on top of `onError` so refactor to not use any of `markdownlint/helpers`, which should make these more robust to future version changes.

Skipping release so that this can go in with the breaking v3 changes.