### PR TITLE
ci: remove test workflow trigger on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
   schedule:
     - cron: '0 22 * * 3'
   workflow_call:


### PR DESCRIPTION
The workflows are structured such that the release workflow (which triggers on push to `main`) also calls the test workflow (so that it can ensure tests pass before releasing). This currently leads to tests running 2x on `main`, so remove the redundant trigger.