### PR TITLE
ci: fix GHA workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: 20.x
+          cache: 'yarn'
+      - name: Install
+        run: yarn install --frozen-lockfile
       - uses: continuousauth/action@c32f05c950d4e6f4abd8d1d8a46269525e2dbf55 # v1.0.3
         with:
           project-id: ${{ secrets.CFA_PROJECT_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,7 @@ jobs:
           cache: 'yarn'
       - name: Install
         run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn build
       - name: Test
         run: yarn test


### PR DESCRIPTION
Picks up improvements from the workflows on `electron/windows-sign` which required a bit of tweaking to get a successful publish.