### PR TITLE
docs: switch badge URL to HTTPS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @electron/lint-roller
 
 [![Test](https://github.com/electron/lint-roller/actions/workflows/test.yml/badge.svg)](https://github.com/electron/lint-roller/actions/workflows/test.yml)
-[![npm version](http://img.shields.io/npm/v/@electron/lint-roller.svg)](https://npmjs.org/package/@electron/lint-roller)
+[![npm version](https://img.shields.io/npm/v/@electron/lint-roller.svg)](https://npmjs.org/package/@electron/lint-roller)
 
 > Markdown linting helpers for Electron org repos
 


### PR DESCRIPTION
Relic from the past, `img.shields.io` docs point you to use `https://` for these badge URLs.