### PR TITLE
feat(lint-markdown-links): disallow absolute links

### DIFF
--- a/tests/fixtures/absolute-internal-link.md
+++ b/tests/fixtures/absolute-internal-link.md
@@ -1,0 +1,9 @@
+# Test
+
+## Target section
+
+This is the target section
+
+## Other Section
+
+Link to [target section](/broken-internal-link.md)

--- a/tests/fixtures/ignorepaths
+++ b/tests/fixtures/ignorepaths
@@ -1,3 +1,4 @@
+**/absolute-internal-link.md
 **/broken-{external,internal}-link.md
 **/broken-cross-file-link.md
 **/valid-cross-file-link.md

--- a/tests/lint-roller-markdown-links.spec.ts
+++ b/tests/lint-roller-markdown-links.spec.ts
@@ -30,7 +30,7 @@ describe('lint-roller-markdown-links', () => {
       '--root',
       FIXTURES_DIR,
       '--ignore',
-      '**/{{broken,valid}-*-link.md,*angle-brackets.md,api-history-*.md}',
+      '**/{{absolute,broken,valid}-*-link.md,*angle-brackets.md,api-history-*.md}',
       '*.md',
     );
 
@@ -41,6 +41,8 @@ describe('lint-roller-markdown-links', () => {
     const { status } = runLintMarkdownLinks(
       '--root',
       FIXTURES_DIR,
+      '--ignore',
+      '**/absolute-internal-link.md',
       '--ignore',
       '**/broken-{external,internal}-link.md',
       '--ignore',
@@ -149,6 +151,28 @@ describe('lint-roller-markdown-links', () => {
       FIXTURES_DIR,
       'twitter-link.md',
       '--fetch-external-links',
+    );
+
+    expect(status).toEqual(0);
+  });
+
+  it('should disallow absolute links by default', () => {
+    const { status, stdout } = runLintMarkdownLinks(
+      '--root',
+      FIXTURES_DIR,
+      'absolute-internal-link.md',
+    );
+
+    expect(stdout).toContain('Absolute link');
+    expect(status).toEqual(1);
+  });
+
+  it('should allow absolute links by with --allow-absolute-links', () => {
+    const { status } = runLintMarkdownLinks(
+      '--root',
+      FIXTURES_DIR,
+      'absolute-internal-link.md',
+      '--allow-absolute-links',
     );
 
     expect(status).toEqual(0);


### PR DESCRIPTION
Absolute links are problematic since they only work from the correct working directory, while a user might open the Markdown file from any number of locations. Adds a `--allow-absolute-links` option as an escape hatch for this behavior.