### PR TITLE
fix: resolve symlinks when checking if script is entrypoint

### DIFF
--- a/bin/lint-markdown-api-history.ts
+++ b/bin/lint-markdown-api-history.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { access, constants, readFile } from 'node:fs/promises';
+import { readFile, realpath } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
@@ -512,7 +512,7 @@ async function init() {
   }
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if ((await realpath(process.argv[1])) === fileURLToPath(import.meta.url)) {
   init().catch((error) => {
     console.error(error);
     process.exit(1);

--- a/bin/lint-markdown-links.ts
+++ b/bin/lint-markdown-links.ts
@@ -210,7 +210,7 @@ function parseCommandLine() {
   }
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if ((await fs.promises.realpath(process.argv[1])) === fileURLToPath(import.meta.url)) {
   const { values: opts, positionals } = parseCommandLine();
 
   if (!opts.root) {

--- a/bin/lint-markdown-standard.ts
+++ b/bin/lint-markdown-standard.ts
@@ -209,7 +209,7 @@ function parseCommandLine() {
   }
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if ((await fs.promises.realpath(process.argv[1])) === fileURLToPath(import.meta.url)) {
   const { values: opts, positionals } = parseCommandLine();
 
   if (!opts.root) {

--- a/bin/lint-markdown-ts-check.ts
+++ b/bin/lint-markdown-ts-check.ts
@@ -319,7 +319,7 @@ function parseCommandLine() {
   }
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if ((await fs.promises.realpath(process.argv[1])) === fileURLToPath(import.meta.url)) {
   const { values: opts, positionals } = parseCommandLine();
 
   if (!opts.root) {


### PR DESCRIPTION
Turns out `process.argv[1]` can be a symlink in `.bin` for these scripts. Node.js is working on adding `import.meta.main` which will be the proper way to do this check in the future, but until then we can resolve the symlink to ensure this works correctly.