### PR TITLE
fix: adjust headers for 429 errors

### DIFF
--- a/bin/lint-markdown-links.ts
+++ b/bin/lint-markdown-links.ts
@@ -38,7 +38,10 @@ async function fetchExternalLink(link: string, checkRedirects = false) {
     const response = await fetch(link, {
       headers: {
         'user-agent':
-          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)  Chrome/122.0.6261.39 Electron/29.0.0 Safari/537.36',
+          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.6261.39 Electron/29.0.0 Safari/537.36',
+        accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+        'accept-language': 'en-US,en;q=0.5',
+        'accept-encoding': 'gzip, deflate, br',
       },
     });
     if (response.status !== 200) {


### PR DESCRIPTION
Fixes an error seen when fetching broken links of late:

https://app.circleci.com/pipelines/github/electron/fiddle/1770/workflows/362babee-0368-4bf0-8ace-1d48cdf28bfb/jobs/7735

Add missing common headers to head off what's likely bot detection.