### PR TITLE
fix: skip npmjs.com links

### DIFF
--- a/bin/lint-markdown-links.ts
+++ b/bin/lint-markdown-links.ts
@@ -34,6 +34,12 @@ const diagnosticOptions: DiagnosticOptions = {
 };
 
 async function fetchExternalLink(link: string, checkRedirects = false) {
+  const url = new URL(link);
+  if (url.hostname.endsWith('.npmjs.com')) {
+    console.log('Skipping npmjs.com link check', link);
+    return true;
+  }
+
   try {
     const response = await fetch(link, {
       headers: {

--- a/tests/fixtures/skipped-external-link.md
+++ b/tests/fixtures/skipped-external-link.md
@@ -1,0 +1,1 @@
+This is a skipped [external link](https://www.npmjs.com/support)

--- a/tests/lint-roller-markdown-links.spec.ts
+++ b/tests/lint-roller-markdown-links.spec.ts
@@ -156,6 +156,18 @@ describe('lint-roller-markdown-links', () => {
     expect(status).toEqual(0);
   });
 
+  it('should skip npmjs.com links', () => {
+    const { status, stdout } = runLintMarkdownLinks(
+      '--root',
+      FIXTURES_DIR,
+      'skipped-external-link.md',
+      '--fetch-external-links',
+    );
+
+    expect(status).toEqual(0);
+    expect(stdout).toContain('Skipping');
+  });
+
   it('should disallow absolute links by default', () => {
     const { status, stdout } = runLintMarkdownLinks(
       '--root',


### PR DESCRIPTION
See [this very detailed discussion comment](https://github.com/orgs/community/discussions/174098#discussioncomment-14461226), but TL;DR is in Sept 2025 npmjs.org started enforcing Cloudflare Bot Management, which is now blocking requests from non-browsers, and we should simply skip these for link checking.